### PR TITLE
fix keys parse bug

### DIFF
--- a/module/cmd/gravity/cmd/root.go
+++ b/module/cmd/gravity/cmd/root.go
@@ -59,7 +59,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 				return err
 			}
 
-			gravityAppTemplate, gravityAppConfig := initAppConfig();
+			gravityAppTemplate, gravityAppConfig := initAppConfig()
 
 			return server.InterceptConfigsPreRunHandler(cmd, gravityAppTemplate, gravityAppConfig)
 		},
@@ -114,6 +114,10 @@ func Execute(rootCmd *cobra.Command) error {
 }
 
 func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
+
+	cfg := sdk.GetConfig()
+	cfg.Seal()
+
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),


### PR DESCRIPTION
originally made the PR against here by mistake: https://github.com/althea-net/cosmos-gravity-bridge/pull/366

same issue was present [in gaia](https://github.com/cosmos/gaia/pull/884) where the `keys parse` command was hanging