### PR TITLE
 Correct invalid deposits test 

### DIFF
--- a/module/x/gravity/types/msgs.go
+++ b/module/x/gravity/types/msgs.go
@@ -336,9 +336,14 @@ func (msg *MsgSendToCosmosClaim) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(msg.Orchestrator); err != nil {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, "orchestrator")
 	}
-	if _, err := IBCAddressFromBech32(msg.CosmosReceiver); err != nil {
-		return sdkerrors.Wrap(err, "cosmos receiver")
-	}
+	// note the destination address is intentionally not validated here, since
+	// MsgSendToEth has it's destination as a string many invalid inputs are possible
+	// the orchestrator will convert these invalid deposits to simply the string invalid'
+	// this is done because the oracle requires an event be processed on Cosmos for each event
+	// nonce on the Ethereum side, otherwise (A) the oracle will never proceed and (B) the funds
+	// sent with the invalid deposit will forever be lost, with no representation minted anywhere
+	// on cosmos. The attestation handler deals with this by managing invalid deposits and placing
+	// them into the community pool
 	if msg.EventNonce == 0 {
 		return fmt.Errorf("nonce == 0")
 	}

--- a/orchestrator/test_runner/src/invalid_events.rs
+++ b/orchestrator/test_runner/src/invalid_events.rs
@@ -133,6 +133,10 @@ fn get_deposit_test_strings() -> Vec<Vec<u8>> {
     let bad = "bad destination".to_string();
     test_strings.push(bad.as_bytes().to_vec());
 
+    // someone is trying to deposit to an eth address
+    let incorrect = "0x00000000000000000000000089bde264cc4e819326482e041d4ae167981935ce";
+    test_strings.push(incorrect.as_bytes().to_vec());
+
     // a very long, but valid utf8 string
     let rand_string: String = thread_rng()
         .sample_iter(&Alphanumeric)
@@ -155,8 +159,7 @@ fn get_deposit_test_strings() -> Vec<Vec<u8>> {
     }
     test_strings.push(rand_invalid_long);
 
-    //test_strings
-    Vec::new()
+    test_strings
 }
 
 fn get_erc20_test_values() -> Vec<Erc20Params> {


### PR DESCRIPTION
Someone sent a deposit to an Ethereum address on the live chain, since
the MsgSendToEth contains a freeform string there are lots of possible
ways it can be invalid.

The oracle component of the orchestrator has the goal of detecting
invalid deposit conditions and replacing them with an indication to the
Gravity Bridge module that this deposit should go into the community
pool. This keeps the oracle moving and prevents one bad deposit from
halting the bridge.

Sadly due to a significant oversight in the creation of the test the
invalid events test was merged with it's invalid deposits section
disabled. This patch restores it, corrects the regression that snuck
in and adds a new test case specific to what failed in production.