### PR TITLE
Fix Mac M1 build

### DIFF
--- a/tests/all-up-test.sh
+++ b/tests/all-up-test.sh
@@ -24,5 +24,13 @@ TEST_TYPE=$1
 ALCHEMY_ID=$2
 set -u
 
+# setup for Mac M1 Compatibility 
+PLATFORM_CMD=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -n $(sysctl -a | grep brand | grep "M1") ]]; then
+       echo "Setting --platform=linux/amd64 for Mac M1 compatibility"
+       PLATFORM_CMD="--platform=linux/amd64"; fi
+fi
+
 # Run new test container instance
-docker run --name gravity_all_up_test_instance --cap-add=NET_ADMIN -t gravity-base /bin/bash /gravity/tests/container-scripts/all-up-test-internal.sh $NODES $TEST_TYPE $ALCHEMY_ID
+docker run --name gravity_all_up_test_instance $PLATFORM_CMD --cap-add=NET_ADMIN -t gravity-base /bin/bash /gravity/tests/container-scripts/all-up-test-internal.sh $NODES $TEST_TYPE $ALCHEMY_ID

--- a/tests/build-container.sh
+++ b/tests/build-container.sh
@@ -13,4 +13,11 @@ pushd $REPOFOLDER
 # Build base container
 git archive --format=tar.gz -o $DOCKERFOLDER/gravity.tar.gz --prefix=gravity/ HEAD
 pushd $DOCKERFOLDER
-docker build -t gravity-base .
+
+PLATFORM_CMD=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -n $(sysctl -a | grep brand | grep "M1") ]]; then
+       echo "Setting --platform=linux/amd64 for Mac M1 compatibility"
+       PLATFORM_CMD="--platform=linux/amd64"; fi
+fi
+docker build -t gravity-base $PLATFORM_CMD .

--- a/tests/build-container.sh
+++ b/tests/build-container.sh
@@ -14,6 +14,7 @@ pushd $REPOFOLDER
 git archive --format=tar.gz -o $DOCKERFOLDER/gravity.tar.gz --prefix=gravity/ HEAD
 pushd $DOCKERFOLDER
 
+# setup for Mac M1 Compatibility 
 PLATFORM_CMD=""
 if [[ "$OSTYPE" == "darwin"* ]]; then
     if [[ -n $(sysctl -a | grep brand | grep "M1") ]]; then

--- a/tests/container-scripts/reload-code.sh
+++ b/tests/container-scripts/reload-code.sh
@@ -19,6 +19,11 @@ done
 
 cd /gravity/module/
 export PATH=$PATH:/usr/local/go/bin
+sudo dnf -y install dnf-plugins-core
+sudo dnf -y config-manager \
+    --add-repo \
+    https://download.docker.com/linux/fedora/docker-ce.repo
+sudo dnf -y install docker-ce docker-ce-cli containerd.io
 make
 make install
 cd /gravity/

--- a/tests/container-scripts/reload-code.sh
+++ b/tests/container-scripts/reload-code.sh
@@ -19,11 +19,6 @@ done
 
 cd /gravity/module/
 export PATH=$PATH:/usr/local/go/bin
-sudo dnf -y install dnf-plugins-core
-sudo dnf -y config-manager \
-    --add-repo \
-    https://download.docker.com/linux/fedora/docker-ce.repo
-sudo dnf -y install docker-ce docker-ce-cli containerd.io
 make
 make install
 cd /gravity/

--- a/tests/start-chains.sh
+++ b/tests/start-chains.sh
@@ -16,5 +16,12 @@ NODES=4
 
 pushd $DIR/../
 
+# setup for Mac M1 compatibility
+PLATFORM_CMD=""
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ -n $(sysctl -a | grep brand | grep "M1") ]]; then
+       echo "Setting --platform=linux/amd64 for Mac M1 compatibility"
+       PLATFORM_CMD="--platform=linux/amd64"; fi
+fi
 # Run new test container instance
-docker run --name gravity_test_instance --mount type=bind,source="$(pwd)"/,target=/gravity --cap-add=NET_ADMIN -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it gravity-base /bin/bash /gravity/tests/container-scripts/reload-code.sh $NODES $TEST_TYPE $ALCHEMY_ID
+docker run --name gravity_test_instance $PLATFORM_CMD --mount type=bind,source="$(pwd)"/,target=/gravity --cap-add=NET_ADMIN -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it gravity-base /bin/bash /gravity/tests/container-scripts/reload-code.sh $NODES $TEST_TYPE $ALCHEMY_ID


### PR DESCRIPTION
**Problem:**
Running bash tests/all-up-test.sh on a Mac with Apple M1 Max processor. Getting error message that eth image can not be found and then failing setup.
```
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

**Solution:**
There are 3 bash scripts that need to be updated: 
- tests/all-up-test.sh
- tests/build-container.sh
- tests/start-chains.sh

In each of these scripts I put an if branch on if Mac OS and M1 processor then append --platform=linux/amd64 to docker run. Linux users should see no change with this PR

**Additional findings:** 
There is a "Docker not found" error when running ./start-chains.sh
```
/usr/bin/which: no docker in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/go/bin:/usr/local/go/bin)
```
It seems like the script still runs to success, however if we want to additionally fix this we can add the following to container-scripts/reload-code.sh before the Make command:

```
sudo dnf -y install dnf-plugins-core
sudo dnf -y config-manager \
    --add-repo \
    https://download.docker.com/linux/fedora/docker-ce.repo
sudo dnf -y install docker-ce docker-ce-cli containerd.io
```