### PR TITLE
Add relay_every_valset option

### DIFF
--- a/orchestrator/gbt/src/default-config.toml
+++ b/orchestrator/gbt/src/default-config.toml
@@ -3,7 +3,12 @@
 # If the built-in relayer is enabled, this relayer is configured in the [relayer] section
 relayer_enabled = false
 
+# Relayer configuration options
 [relayer]
+# If we check profitability before relaying
 valset_market_enabled = false
 batch_market_enabled = true
 logic_call_market_enabled = true
+# If we relay every possible valset, only applicable when not checking
+# for profitability
+relay_every_valset = false

--- a/orchestrator/gbt/src/main.rs
+++ b/orchestrator/gbt/src/main.rs
@@ -74,7 +74,7 @@ async fn main() {
             orchestrator(orchestrator_opts, address_prefix, &home_dir, config).await
         }
         SubCommand::Relayer(relayer_opts) => {
-            relayer(relayer_opts, address_prefix, &home_dir, &config.relayer).await
+            relayer(relayer_opts, address_prefix, &home_dir, config.relayer).await
         }
         SubCommand::Init(init_opts) => init_config(init_opts, home_dir),
     }

--- a/orchestrator/gbt/src/relayer.rs
+++ b/orchestrator/gbt/src/relayer.rs
@@ -16,7 +16,7 @@ pub async fn relayer(
     args: RelayerOpts,
     address_prefix: String,
     home_dir: &Path,
-    config: &RelayerConfig,
+    config: RelayerConfig,
 ) {
     let cosmos_grpc = args.cosmos_grpc;
     let ethereum_rpc = args.ethereum_rpc;

--- a/orchestrator/gravity_utils/src/error.rs
+++ b/orchestrator/gravity_utils/src/error.rs
@@ -27,6 +27,7 @@ pub enum GravityError {
     GravityGrpcError(Status),
     InsufficientVotingPowerToPass(String),
     ParseBigIntError(ParseBigIntError),
+    ValsetUpToDate,
 }
 
 impl fmt::Display for GravityError {
@@ -56,6 +57,12 @@ impl fmt::Display for GravityError {
                 write!(f, "{}", val)
             }
             GravityError::ParseBigIntError(val) => write!(f, "Failed to parse big integer {}", val),
+            GravityError::ValsetUpToDate => {
+                write!(
+                    f,
+                    "latest validator set is synced between Ethereum and Cosmos"
+                )
+            }
         }
     }
 }

--- a/orchestrator/gravity_utils/src/types/config.rs
+++ b/orchestrator/gravity_utils/src/types/config.rs
@@ -12,19 +12,25 @@ pub struct GravityBridgeToolsConfig {
 /// Relayer configuration options
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct RelayerConfig {
-    #[serde(default = "default_valset_market_enabled")]
-    pub valset_market_enabled: bool,
+    #[serde(default = "default_valset_relaying_mode")]
+    pub valset_relaying_mode: ValsetRelayingMode,
     #[serde(default = "default_batch_market_enabled")]
     pub batch_market_enabled: bool,
     #[serde(default = "default_logic_call_market_enabled")]
     pub logic_call_market_enabled: bool,
 }
 
-// Disabled for bridge launch as some valsets need to be relayed before the
-// ethereum-representation of cosmos tokens appear on uniswap. Enabling this would
-// halt the bridge launch.
-fn default_valset_market_enabled() -> bool {
-    false
+/// The various possible modes for relaying validator set updates
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ValsetRelayingMode {
+    /// Only ever relay profitable valsets, regardless of all other
+    /// considerations
+    ProfitableOnly,
+    /// Relay validator sets when continued operation of the chain
+    /// requires it, this will cost some ETH
+    Altruistic,
+    /// Relay every validator set update, mostly for developer use
+    EveryValset,
 }
 
 fn default_batch_market_enabled() -> bool {
@@ -35,10 +41,14 @@ fn default_logic_call_market_enabled() -> bool {
     true
 }
 
+fn default_valset_relaying_mode() -> ValsetRelayingMode {
+    ValsetRelayingMode::Altruistic
+}
+
 impl Default for RelayerConfig {
     fn default() -> Self {
         RelayerConfig {
-            valset_market_enabled: default_valset_market_enabled(),
+            valset_relaying_mode: default_valset_relaying_mode(),
             batch_market_enabled: default_batch_market_enabled(),
             logic_call_market_enabled: default_logic_call_market_enabled(),
         }
@@ -46,7 +56,7 @@ impl Default for RelayerConfig {
 }
 
 /// Orchestrator configuration options
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub struct OrchestratorConfig {
     /// If this Orchestrator should run an integrated relayer or not
     #[serde(default = "default_relayer_enabled")]

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -76,7 +76,7 @@ pub async fn orchestrator_main_loop(
         web3,
         grpc_client.clone(),
         gravity_contract_address,
-        &config.relayer,
+        config.relayer,
     );
 
     // if the relayer is not enabled we just don't start the future

--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -37,7 +37,7 @@ pub async fn relay_batches(
     gravity_contract_address: EthAddress,
     gravity_id: String,
     timeout: Duration,
-    config: &RelayerConfig,
+    config: RelayerConfig,
 ) {
     let possible_batches =
         get_batches_and_signatures(current_valset.clone(), grpc_client, gravity_id.clone()).await;
@@ -180,7 +180,7 @@ async fn submit_batches(
     gravity_id: String,
     timeout: Duration,
     possible_batches: HashMap<EthAddress, Vec<SubmittableBatch>>,
-    config: &RelayerConfig,
+    config: RelayerConfig,
 ) {
     let our_ethereum_address = ethereum_key.to_address();
     let ethereum_block_height = if let Ok(bn) = web3.eth_block_number().await {

--- a/orchestrator/relayer/src/logic_call_relaying.rs
+++ b/orchestrator/relayer/src/logic_call_relaying.rs
@@ -79,7 +79,7 @@ pub async fn relay_logic_calls(
     gravity_contract_address: EthAddress,
     gravity_id: String,
     timeout: Duration,
-    config: &RelayerConfig,
+    config: RelayerConfig,
 ) {
     let our_ethereum_address = ethereum_key.to_address();
 

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -21,7 +21,7 @@ pub async fn relayer_main_loop(
     web3: Web3,
     grpc_client: GravityQueryClient<Channel>,
     gravity_contract_address: EthAddress,
-    relayer_config: &RelayerConfig,
+    relayer_config: RelayerConfig,
 ) {
     let mut grpc_client = grpc_client;
     loop {
@@ -52,7 +52,7 @@ pub async fn relayer_main_loop(
             gravity_contract_address,
             gravity_id.clone(),
             LOOP_SPEED,
-            relayer_config,
+            relayer_config.clone(),
         )
         .await;
 
@@ -64,7 +64,7 @@ pub async fn relayer_main_loop(
             gravity_contract_address,
             gravity_id.clone(),
             LOOP_SPEED,
-            relayer_config,
+            relayer_config.clone(),
         )
         .await;
 
@@ -76,7 +76,7 @@ pub async fn relayer_main_loop(
             gravity_contract_address,
             gravity_id.clone(),
             LOOP_SPEED,
-            relayer_config,
+            relayer_config.clone(),
         )
         .await;
 

--- a/orchestrator/test_runner/src/pause_bridge.rs
+++ b/orchestrator/test_runner/src/pause_bridge.rs
@@ -37,13 +37,7 @@ pub async fn pause_bridge_test(
     assert!(params.bridge_active);
 
     let no_relay_market_config = create_default_test_config();
-    start_orchestrators(
-        keys.clone(),
-        gravity_address,
-        false,
-        no_relay_market_config.clone(),
-    )
-    .await;
+    start_orchestrators(keys.clone(), gravity_address, false, no_relay_market_config).await;
 
     // generate an address for coin sending tests, this ensures test imdepotency
     let user_keys = get_user_key();

--- a/orchestrator/test_runner/src/unhalt_bridge.rs
+++ b/orchestrator/test_runner/src/unhalt_bridge.rs
@@ -50,13 +50,7 @@ pub async fn unhalt_bridge_test(
         payer: None,
     };
 
-    start_orchestrators(
-        keys.clone(),
-        gravity_address,
-        false,
-        no_relay_market_config.clone(),
-    )
-    .await;
+    start_orchestrators(keys.clone(), gravity_address, false, no_relay_market_config).await;
     let lying_validators: Vec<CosmosPrivateKey> =
         keys[1..3].iter().map(|key| key.orch_key).collect();
 

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -26,6 +26,7 @@ use gravity_proto::cosmos_sdk_proto::cosmos::staking::v1beta1::QueryValidatorsRe
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
 use gravity_proto::gravity::MsgSendToCosmosClaim;
 use gravity_utils::types::GravityBridgeToolsConfig;
+use gravity_utils::types::ValsetRelayingMode;
 use orchestrator::main_loop::orchestrator_main_loop;
 use rand::Rng;
 use std::thread;
@@ -50,8 +51,8 @@ pub fn create_default_test_config() -> GravityBridgeToolsConfig {
     // enable integrated relayer by default for tests
     no_relay_market_config.orchestrator.relayer_enabled = true;
     no_relay_market_config.relayer.batch_market_enabled = false;
-    no_relay_market_config.relayer.valset_market_enabled = false;
     no_relay_market_config.relayer.logic_call_market_enabled = false;
+    no_relay_market_config.relayer.valset_relaying_mode = ValsetRelayingMode::EveryValset;
     no_relay_market_config
 }
 


### PR DESCRIPTION
This is the first in a sequence of patches focused on relaying improvements.

The primary goal of this change is to make it safe for a user to run the
relayer with the default settings without valset relaying exhausting all
their funds.

Previously there where two sets of validator set relaying behavior, one
where every valset was relayed and one where only profitable valsets
where relayed.

Relaying every valset is extremely wasteful in terms of gas and isn't
good default behavior for an altruistic user. Relaying only profitable
valsets is a valid choice, but will not keep the chain running correctly
if there are no rewards or the reward is too low.

This new default state, defined by having both relay_every_valset and
valset_relay_market as false in the config. Will only relay validator
sets when it becomes absolutely required for the bridge to continue
functioning. This should be extremely infrequent, with timing on the
order of several weeks.

This patch also contains a three other changes.

1) Orchestrator and Relayer configs are made 'copy' and references to
   them are removed throughout the relaying call stack
2) Valset relaying has been refactored and many comments and variable
   names touched up to improve readability and better define what each
   step is intended to do
3) valset_relaying.rs has been re-ordered so that a top to bottom
   reading of the file matches the call stack.