### PR TITLE
Use contact get_balance

### DIFF
--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -168,16 +168,17 @@ pub async fn main() {
     // for things
     send_eth_to_orchestrators(&keys, &web30).await;
 
-    assert!(check_cosmos_balance(
-        &get_test_token_name(),
-        keys[0]
-            .validator_key
-            .to_address(&contact.get_prefix())
-            .unwrap(),
-        &contact
-    )
-    .await
-    .is_some());
+    assert!(contact
+        .get_balance(
+            keys[0]
+                .validator_key
+                .to_address(&contact.get_prefix())
+                .unwrap(),
+            get_test_token_name(),
+        )
+        .await
+        .unwrap()
+        .is_some());
 
     // This segment contains optional tests, by default we run a happy path test
     // this tests all major functionality of Gravity once or twice.

--- a/orchestrator/test_runner/src/pause_bridge.rs
+++ b/orchestrator/test_runner/src/pause_bridge.rs
@@ -104,8 +104,13 @@ pub async fn pause_bridge_test(
     }
 
     // Try to create a batch and send tokens to Ethereum
-    let coin = check_cosmos_balance("gravity", user_keys.cosmos_address, contact)
+    let coin = contact
+        .get_balance(
+            user_keys.cosmos_address,
+            format!("gravity{}", erc20_address),
+        )
         .await
+        .unwrap()
         .unwrap();
     let token_name = coin.denom;
     let amount = coin.amount;
@@ -179,8 +184,13 @@ pub async fn pause_bridge_test(
     assert!(params.bridge_active);
 
     // finally we check that our batch executes and our new withdraw processes
-    let res = check_cosmos_balance("gravity", user_keys.cosmos_address, contact)
+    let res = contact
+        .get_balance(
+            user_keys.cosmos_address,
+            format!("gravity{}", erc20_address),
+        )
         .await
+        .unwrap()
         .unwrap();
     // check that our balance is equal to 200 (two deposits) minus 95 (sent to eth) - 1 (fee) - 1 (fee for batch request)
     // NOTE this makes the test not imdepotent but it's not anyways, a crash may leave the bridge halted

--- a/orchestrator/test_runner/src/relay_market.rs
+++ b/orchestrator/test_runner/src/relay_market.rs
@@ -2,9 +2,7 @@
 //! relayers utilize web30 to interact with a testnet to obtain coin swap values
 //! and determine whether relays should happen or not
 use crate::happy_path::test_erc20_deposit_panic;
-use crate::utils::{
-    check_cosmos_balance, get_erc20_balance_safe, send_one_eth, start_orchestrators, ValidatorKeys,
-};
+use crate::utils::{get_erc20_balance_safe, send_one_eth, start_orchestrators, ValidatorKeys};
 use crate::ADDRESS_PREFIX;
 use crate::MINER_PRIVATE_KEY;
 use crate::TOTAL_TIMEOUT;
@@ -172,8 +170,10 @@ async fn setup_batch_test(
         None,
     )
     .await;
-    let cdai_held = check_cosmos_balance("gravity", dest_cosmos_address, contact)
+    let cdai_held = contact
+        .get_balance(dest_cosmos_address, format!("gravity{}", erc20_contract))
         .await
+        .unwrap()
         .unwrap();
     let cdai_name = cdai_held.denom.clone();
     let cdai_amount = cdai_held.amount.clone();

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -92,22 +92,6 @@ pub fn get_coins(denom: &str, balances: &[Coin]) -> Option<Coin> {
     None
 }
 
-pub async fn check_cosmos_balance(
-    denom: &str,
-    address: CosmosAddress,
-    contact: &Contact,
-) -> Option<Coin> {
-    let account_info = contact.get_balances(address).await.unwrap();
-    trace!("Cosmos balance {:?}", account_info);
-    for coin in account_info {
-        // make sure the name and amount is correct
-        if coin.denom.starts_with(denom) {
-            return Some(coin);
-        }
-    }
-    None
-}
-
 /// This is a hardcoded very high gas value used in transaction stress test to counteract rollercoaster
 /// gas prices due to the way that test fills blocks
 pub const HIGH_GAS_PRICE: u64 = 1_000_000_000u64;


### PR DESCRIPTION
This patch replaces a poorly specified utility function that we used in
our Rust test environment to find gravity coins in test account
balances.

Since Contact did not implement get_balance() but instead only
get_balances() we would iterate over all tokens to find the one we where
interested in. Furthermore we would only check the prefix rather than
the full exact token name.

Removing this behavior should improve test accuracy and also provide a
minor complexity reduction.