### PR TITLE
Fix endblock panic for simulations where there are no bonded validators

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -37,7 +37,9 @@ func createValsets(ctx sdk.Context, k keeper.Keeper) {
 	if latestValset != nil {
 		vs, err := k.GetCurrentValset(ctx)
 		if err != nil {
-			// log error
+			ctx.Logger().Error("invalid current valset members",
+					"cause", err.Error(),
+			)
 			return
 		}
 		intCurrMembers, err := types.BridgeValidators(vs.Members).ToInternal()

--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -37,10 +37,15 @@ func createValsets(ctx sdk.Context, k keeper.Keeper) {
 	if latestValset != nil {
 		vs, err := k.GetCurrentValset(ctx)
 		if err != nil {
-			ctx.Logger().Error("invalid current valset members",
+			// this condition should only occur in the simulator
+			// ref : https://github.com/Gravity-Bridge/Gravity-Bridge/issues/35
+			if err == types.ErrNoValidators {
+				ctx.Logger().Error("no bonded validators",
 					"cause", err.Error(),
-			)
-			return
+				)
+				return
+			}
+			panic(err)
 		}
 		intCurrMembers, err := types.BridgeValidators(vs.Members).ToInternal()
 		if err != nil {
@@ -82,7 +87,6 @@ func pruneValsets(ctx sdk.Context, k keeper.Keeper, params types.Params) {
 }
 
 func slashing(ctx sdk.Context, k keeper.Keeper) {
-
 	params := k.GetParams(ctx)
 
 	// Slash validator for not confirming valset requests, batch requests, logic call requests
@@ -352,7 +356,6 @@ func prepBatchConfirms(ctx sdk.Context, k keeper.Keeper, batch types.InternalOut
 // signatures. This is distinct from validator sets, which includes unbonding validators
 // because validator set updates must succeed as validators leave the set, batches will just be re-created
 func batchSlashing(ctx sdk.Context, k keeper.Keeper, params types.Params) {
-
 	// We look through the full bonded set (the active set)
 	// and we slash users who haven't signed a batch confirmation that is >15hrs in blocks old
 	var maxHeight uint64
@@ -430,7 +433,6 @@ func prepLogicCallConfirms(ctx sdk.Context, k keeper.Keeper, call types.Outgoing
 // signatures. This is distinct from validator sets, which includes unbonding validators
 // because validator set updates must succeed as validators leave the set, logicCalls will just be re-created
 func logicCallSlashing(ctx sdk.Context, k keeper.Keeper, params types.Params) {
-
 	// We look through the full bonded set (the active set)
 	// and we slash users who haven't signed a batch confirmation that is >15hrs in blocks old
 	var maxHeight uint64

--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -35,7 +35,12 @@ func createValsets(ctx sdk.Context, k keeper.Keeper) {
 
 	significantPowerDiff := false
 	if latestValset != nil {
-		intCurrMembers, err := types.BridgeValidators(k.GetCurrentValset(ctx).Members).ToInternal()
+		vs, err := k.GetCurrentValset(ctx)
+		if err != nil {
+			// log error
+			return
+		}
+		intCurrMembers, err := types.BridgeValidators(vs.Members).ToInternal()
 		if err != nil {
 			panic(sdkerrors.Wrap(err, "invalid current valset members"))
 		}

--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -54,7 +54,8 @@ func TestValsetSlashing_ValsetCreated_Before_ValidatorBonded(t *testing.T) {
 	pk := input.GravityKeeper
 	params := input.GravityKeeper.GetParams(ctx)
 
-	vs := pk.GetCurrentValset(ctx)
+	vs, err := pk.GetCurrentValset(ctx)
+	require.NoError(t, err)
 	height := uint64(ctx.BlockHeight()) - (params.SignedValsetsWindow + 1)
 	vs.Height = height
 	vs.Nonce = height
@@ -75,7 +76,8 @@ func TestValsetSlashing_ValsetCreated_After_ValidatorBonded(t *testing.T) {
 	params := input.GravityKeeper.GetParams(ctx)
 
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(params.SignedValsetsWindow) + 2)
-	vs := pk.GetCurrentValset(ctx)
+	vs, err := pk.GetCurrentValset(ctx)
+	require.NoError(t, err)
 	height := uint64(ctx.BlockHeight()) - (params.SignedValsetsWindow + 1)
 	vs.Height = height
 
@@ -240,7 +242,8 @@ func TestValsetEmission(t *testing.T) {
 	pk := input.GravityKeeper
 
 	// Store a validator set with a power change as the most recent validator set
-	vs := pk.GetCurrentValset(ctx)
+	vs, err := pk.GetCurrentValset(ctx)
+	require.NoError(t, err)
 	vs.Nonce--
 	internalMembers, err := types.BridgeValidators(vs.Members).ToInternal()
 	require.NoError(t, err)

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -606,7 +606,8 @@ func TestMsgValsetConfirm(t *testing.T) {
 	h := NewHandler(input.GravityKeeper)
 
 	// set a validator set in the store
-	vs := k.GetCurrentValset(ctx)
+	vs, err := k.GetCurrentValset(ctx)
+	require.NoError(t, err)
 	vs.Height = uint64(1)
 	vs.Nonce = uint64(1)
 	k.StoreValset(ctx, vs)

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -36,7 +36,8 @@ func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types
 func (k Keeper) CurrentValset(
 	c context.Context,
 	req *types.QueryCurrentValsetRequest) (*types.QueryCurrentValsetResponse, error) {
-	return &types.QueryCurrentValsetResponse{Valset: k.GetCurrentValset(sdk.UnwrapSDKContext(c))}, nil
+	vs, _ := k.GetCurrentValset(sdk.UnwrapSDKContext(c))
+	return &types.QueryCurrentValsetResponse{Valset: vs}, nil
 }
 
 // ValsetRequest queries the ValsetRequest of the gravity module

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -29,14 +29,16 @@ func (k Keeper) Params(c context.Context, req *types.QueryParamsRequest) (*types
 	var params types.Params
 	k.paramSpace.GetParamSet(sdk.UnwrapSDKContext(c), &params)
 	return &types.QueryParamsResponse{Params: params}, nil
-
 }
 
 // CurrentValset queries the CurrentValset of the gravity module
 func (k Keeper) CurrentValset(
 	c context.Context,
 	req *types.QueryCurrentValsetRequest) (*types.QueryCurrentValsetResponse, error) {
-	vs, _ := k.GetCurrentValset(sdk.UnwrapSDKContext(c))
+	vs, err := k.GetCurrentValset(sdk.UnwrapSDKContext(c))
+	if err != nil {
+		return &types.QueryCurrentValsetResponse{}, err
+	}
 	return &types.QueryCurrentValsetResponse{Valset: vs}, nil
 }
 
@@ -176,7 +178,6 @@ func (k Keeper) LastPendingLogicCallByAddr(
 	if found {
 		return &types.QueryLastPendingLogicCallByAddrResponse{Call: pendingLogicReq}, nil
 	} else {
-
 		return &types.QueryLastPendingLogicCallByAddrResponse{Call: nil}, nil
 	}
 }

--- a/module/x/gravity/keeper/keeper_test.go
+++ b/module/x/gravity/keeper/keeper_test.go
@@ -92,7 +92,8 @@ func TestCurrentValsetNormalization(t *testing.T) {
 		spec := spec
 		t.Run(msg, func(t *testing.T) {
 			input, ctx := SetupTestChain(t, spec.srcPowers, true)
-			r := input.GravityKeeper.GetCurrentValset(ctx)
+			r, err := input.GravityKeeper.GetCurrentValset(ctx)
+			require.NoError(t, err)
 			rMembers, err := types.BridgeValidators(r.Members).ToInternal()
 			require.NoError(t, err)
 			assert.Equal(t, spec.expPowers, rMembers.GetPowers())
@@ -194,7 +195,8 @@ func TestLastSlashedValsetNonce(t *testing.T) {
 	input, ctx := SetupFiveValChain(t)
 	k := input.GravityKeeper
 
-	vs := k.GetCurrentValset(ctx)
+	vs, err := k.GetCurrentValset(ctx)
+	require.NoError(t, err)
 
 	i := 1
 	for ; i < 10; i++ {

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -25,7 +25,10 @@ import (
 // and perhaps take action based on that use k.GetCurrentValset
 // i.e. {"nonce": 1, "memebers": [{"eth_addr": "foo", "power": 11223}]}
 func (k Keeper) SetValsetRequest(ctx sdk.Context) types.Valset {
-	valset, _ := k.GetCurrentValset(ctx)
+	valset, err := k.GetCurrentValset(ctx)
+	if err != nil {
+		panic(err)
+	}
 	k.StoreValset(ctx, valset)
 	k.SetLatestValsetNonce(ctx, valset.Nonce)
 
@@ -254,7 +257,7 @@ func (k Keeper) IterateValsetBySlashedValsetNonce(ctx sdk.Context, lastSlashedVa
 func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 	validators := k.StakingKeeper.GetBondedValidatorsByPower(ctx)
 	if len(validators) == 0 {
-		return types.Valset{}, fmt.Errorf("validator set is empty")
+		return types.Valset{}, types.ErrNoValidators
 	}
 	// allocate enough space for all validators, but len zero, we then append
 	// so that we have an array with extra capacity but the correct length depending
@@ -266,7 +269,7 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 	for _, validator := range validators {
 		val := validator.GetOperator()
 		if err := sdk.VerifyAddressFormat(val); err != nil {
-			panic(sdkerrors.Wrapf(err, "invalid validator address in current valset %v", val))
+			return types.Valset{}, sdkerrors.Wrap(err, types.ErrInvalidValAddress.Error())
 		}
 
 		p := sdk.NewInt(k.StakingKeeper.GetLastValidatorPower(ctx, val))
@@ -275,7 +278,7 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 			bv := types.BridgeValidator{Power: p.Uint64(), EthereumAddress: ethAddr.GetAddress()}
 			ibv, err := types.NewInternalBridgeValidator(bv)
 			if err != nil {
-				panic(sdkerrors.Wrapf(err, "discovered invalid eth address stored for validator %v", val))
+				return types.Valset{}, sdkerrors.Wrapf(err, types.ErrInvalidEthAddress.Error(), val)
 			}
 			bridgeValidators = append(bridgeValidators, ibv)
 			totalPower = totalPower.Add(p)
@@ -307,7 +310,7 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 
 	valset, err := types.NewValset(valsetNonce, uint64(ctx.BlockHeight()), bridgeValidators, rewardAmount, *rewardToken)
 	if err != nil {
-		panic(sdkerrors.Wrap(err, "generated invalid valset"))
+		return types.Valset{}, (sdkerrors.Wrap(err, types.ErrInvalidValset.Error()))
 	}
 	return *valset, nil
 }

--- a/module/x/gravity/keeper/querier.go
+++ b/module/x/gravity/keeper/querier.go
@@ -31,7 +31,7 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryCurrentValset(ctx sdk.Context, keeper Keeper) ([]byte, error) {
-	valset := keeper.GetCurrentValset(ctx)
+	valset, _ := keeper.GetCurrentValset(ctx)
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, valset)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())

--- a/module/x/gravity/keeper/querier.go
+++ b/module/x/gravity/keeper/querier.go
@@ -31,7 +31,10 @@ func NewQuerier(keeper Keeper) sdk.Querier {
 }
 
 func queryCurrentValset(ctx sdk.Context, keeper Keeper) ([]byte, error) {
-	valset, _ := keeper.GetCurrentValset(ctx)
+	valset, err := keeper.GetCurrentValset(ctx)
+	if err != nil {
+		return nil, err
+	}
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, valset)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())

--- a/module/x/gravity/keeper/querier_test.go
+++ b/module/x/gravity/keeper/querier_test.go
@@ -927,7 +927,8 @@ func TestQueryCurrentValset(t *testing.T) {
 	input, _ := SetupFiveValChain(t)
 	sdkCtx := input.Context
 
-	currentValset := input.GravityKeeper.GetCurrentValset(sdkCtx)
+	currentValset, err := input.GravityKeeper.GetCurrentValset(sdkCtx)
+	require.NoError(t, err)
 
 	assert.Equal(t, expectedValset, currentValset)
 }

--- a/module/x/gravity/types/errors.go
+++ b/module/x/gravity/types/errors.go
@@ -16,4 +16,8 @@ var (
 	ErrNonContiguousEventNonce = sdkerrors.Register(ModuleName, 9, "non contiguous event nonce")
 	ErrResetDelegateKeys       = sdkerrors.Register(ModuleName, 10, "can not set orchestrator addresses more than once")
 	ErrMismatched              = sdkerrors.Register(ModuleName, 11, "mismatched")
+	ErrNoValidators            = sdkerrors.Register(ModuleName, 12, "no bonded validators in active set")
+	ErrInvalidValAddress       = sdkerrors.Register(ModuleName, 13, "invalid validator address in current valset %v")
+	ErrInvalidEthAddress       = sdkerrors.Register(ModuleName, 14, "discovered invalid eth address stored for validator %v")
+	ErrInvalidValset           = sdkerrors.Register(ModuleName, 15, "generated invalid valset")
 )


### PR DESCRIPTION
Handles a case for simulations where there are no bonded validators

Closes #35