### PR TITLE
Fix double call of RegisterProposalTypes

### DIFF
--- a/module/x/gravity/client/cli/tx.go
+++ b/module/x/gravity/client/cli/tx.go
@@ -20,8 +20,10 @@ import (
 )
 
 func GetTxCmd(storeKey string) *cobra.Command {
-	// needed for governance proposal txs
+	// needed for governance proposal txs in cli case
+	// internal check prevents double registration in node case
 	keeper.RegisterProposalTypes()
+
 	//nolint: exhaustivestruct
 	gravityTxCmd := &cobra.Command{
 		Use:                        types.ModuleName,

--- a/module/x/gravity/keeper/governance_proposals.go
+++ b/module/x/gravity/keeper/governance_proposals.go
@@ -14,12 +14,28 @@ import (
 // this file contains code related to custom governance proposals
 
 func RegisterProposalTypes() {
-	govtypes.RegisterProposalType(types.ProposalTypeUnhaltBridge)
-	govtypes.RegisterProposalTypeCodec(&types.UnhaltBridgeProposal{}, "gravity/UnhaltBridge")
-	govtypes.RegisterProposalType(types.ProposalTypeAirdrop)
-	govtypes.RegisterProposalTypeCodec(&types.AirdropProposal{}, "gravity/Airdrop")
-	govtypes.RegisterProposalType(types.ProposalTypeIBCMetadata)
-	govtypes.RegisterProposalTypeCodec(&types.IBCMetadataProposal{}, "gravity/IBCMetadata")
+	// use of prefix stripping to prevent a typo between the proposal we check
+	// and the one we register, any issues with the registration string will prevent
+	// the proposal from working. We must check for double registration so that cli commands
+	// submitting these proposals work.
+	// For some reason the cli code is run during app.go startup, but of course app.go is not
+	// run during operation of one off tx commands, so we need to run this 'twice'
+	prefix := "gravity/"
+	metadata := "gravity/IBCMetadata"
+	if !govtypes.IsValidProposalType(strings.TrimPrefix(metadata, prefix)) {
+		govtypes.RegisterProposalType(types.ProposalTypeIBCMetadata)
+		govtypes.RegisterProposalTypeCodec(&types.IBCMetadataProposal{}, metadata)
+	}
+	unhalt := "gravity/UnhaltBridge"
+	if !govtypes.IsValidProposalType(strings.TrimPrefix(unhalt, prefix)) {
+		govtypes.RegisterProposalType(types.ProposalTypeUnhaltBridge)
+		govtypes.RegisterProposalTypeCodec(&types.UnhaltBridgeProposal{}, unhalt)
+	}
+	airdrop := "gravity/Airdrop"
+	if !govtypes.IsValidProposalType(strings.TrimPrefix(airdrop, prefix)) {
+		govtypes.RegisterProposalType(types.ProposalTypeAirdrop)
+		govtypes.RegisterProposalTypeCodec(&types.AirdropProposal{}, airdrop)
+	}
 }
 
 func NewGravityProposalHandler(k Keeper) govtypes.Handler {


### PR DESCRIPTION
A recent commit "register proposal types for the cli" caused the gravity
node to panic on startup due to double registration of proposal types.
Being overconfident that it was a simple fixed I pushed this straight to
master and broke the tests there.

This patch fixes the issue, which somehow invovles App.go calling all
the CLI command code and duplicating the proposal registration. We need
to register proposals in the CLI for the case where we are not running a
full node and App.go does not register the proposal type. The ultimate
soltuion is a check to prevent double registration.