### PR TITLE
Fix SetOrchestratorAddress duplicate key check

### DIFF
--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -57,7 +57,7 @@ func (k msgServer) SetOrchestratorAddress(c context.Context, msg *types.MsgSetOr
 		if delegateKeys[i].EthAddress == addr.GetAddress() {
 			return nil, sdkerrors.Wrap(err, "Duplicate Ethereum Key")
 		}
-		if delegateKeys[i].Orchestrator == addr.GetAddress() {
+		if delegateKeys[i].Orchestrator == orch.String() {
 			return nil, sdkerrors.Wrap(err, "Duplicate Orchestrator Key")
 		}
 	}


### PR DESCRIPTION
I noticed this check for duplicate delegate keys might not be correct, it compares both EthAddress and Orchestrator with addr.GetAddress which is ethereum address.