### PR TITLE
ValSet/Batch confirmations not removed from the store #41- fix

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -81,6 +81,7 @@ func pruneValsets(ctx sdk.Context, k keeper.Keeper, params types.Params) {
 		for _, set := range sets {
 			if set.Nonce < lastObserved.Nonce && set.Height < earliestToPrune {
 				k.DeleteValset(ctx, set.Nonce)
+				k.DeleteValsetConfirms(ctx, set.Nonce)
 			}
 		}
 	}

--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -330,6 +330,26 @@ func TestBatchTimeout(t *testing.T) {
 	gotSecondBatch := input.GravityKeeper.GetOutgoingTXBatch(ctx, b2.TokenContract, b2.BatchNonce)
 	require.NotNil(t, gotSecondBatch)
 
+	// persist confirmations for second batch to test their deletion on batch timeout
+	for i, orch := range keeper.OrchAddrs {
+		ethAddr, err := types.NewEthAddress(keeper.EthAddrs[i].String())
+		require.NoError(t, err)
+
+		conf := &types.MsgConfirmBatch{
+			Nonce:         b2.BatchNonce,
+			TokenContract: b2.TokenContract.GetAddress(),
+			EthSigner:     ethAddr.GetAddress(),
+			Orchestrator:  orch.String(),
+			Signature:     "dummysig",
+		}
+
+		input.GravityKeeper.SetBatchConfirm(ctx, conf)
+	}
+
+	// verify that confirms are persisted
+	secondBatchConfirms := input.GravityKeeper.GetBatchConfirmByNonceAndTokenContract(ctx, b2.BatchNonce, b2.TokenContract)
+	require.Equal(t, len(keeper.OrchAddrs), len(secondBatchConfirms))
+
 	// when, way into the future
 	ctx = ctx.WithBlockTime(now)
 	ctx = ctx.WithBlockHeight(9)
@@ -359,4 +379,49 @@ func TestBatchTimeout(t *testing.T) {
 	require.Nil(t, gotSecondBatch)
 	gotThirdBatch = input.GravityKeeper.GetOutgoingTXBatch(ctx, b3.TokenContract, b3.BatchNonce)
 	require.NotNil(t, gotThirdBatch)
+
+	// verify that second batch confirms are deleted
+	secondBatchConfirms = input.GravityKeeper.GetBatchConfirmByNonceAndTokenContract(ctx, b2.BatchNonce, b2.TokenContract)
+	require.Equal(t, 0, len(secondBatchConfirms))
+}
+
+func TestValsetPruning(t *testing.T) {
+	input, ctx := keeper.SetupFiveValChain(t)
+	pk := input.GravityKeeper
+	params := pk.GetParams(ctx)
+
+	// Create new validator set with nonce 1
+	pk.SetValsetRequest(ctx)
+	firstValsetNonce := pk.GetLatestValsetNonce(ctx)
+	require.NotNil(t, pk.GetValset(ctx, firstValsetNonce))
+	require.True(t, len(pk.GetValsets(ctx)) == 1)
+
+	// Create validator set confirmations
+	for i, orch := range keeper.OrchAddrs {
+		ethAddr, err := types.NewEthAddress(keeper.EthAddrs[i].String())
+		require.NoError(t, err)
+
+		conf := types.NewMsgValsetConfirm(firstValsetNonce, *ethAddr, orch, "dummysig")
+		pk.SetValsetConfirm(ctx, *conf)
+	}
+
+	require.True(t, len(pk.GetValsetConfirms(ctx, firstValsetNonce)) == len(keeper.OrchAddrs))
+
+	// Create new validator set with nonce 2
+	pk.SetValsetRequest(ctx)
+	require.True(t, len(pk.GetValsets(ctx)) == 2)
+	valset := pk.GetValset(ctx, pk.GetLatestValsetNonce(ctx))
+	require.NotNil(t, valset)
+
+	// Set validator set with nonce 2 as last observed
+	pk.SetLastObservedValset(ctx, *valset)
+	require.Equal(t, valset.Nonce, pk.GetLastObservedValset(ctx).Nonce)
+
+	// Advance enough blocks so that old validator set gets removed in EndBlocker
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + int64(params.SignedValsetsWindow+1)).WithBlockTime(time.Now().UTC())
+
+	// EndBlocker should cleanup validator set with nonce 1 and it's confirmations
+	EndBlocker(ctx, pk)
+	require.Nil(t, pk.GetValset(ctx, firstValsetNonce))
+	require.Equal(t, 0, len(pk.GetValsetConfirms(ctx, firstValsetNonce)))
 }

--- a/module/x/gravity/keeper/batch.go
+++ b/module/x/gravity/keeper/batch.go
@@ -142,6 +142,8 @@ func (k Keeper) OutgoingTxBatchExecuted(ctx sdk.Context, tokenContract types.Eth
 
 	// Delete batch since it is finished
 	k.DeleteBatch(ctx, *b)
+	// Delete it's confirmations as well
+	k.DeleteBatchConfirms(ctx, *b)
 }
 
 // StoreBatch stores a transaction batch, it will refuse to overwrite an existing
@@ -246,6 +248,8 @@ func (k Keeper) CancelOutgoingTXBatch(ctx sdk.Context, tokenContract types.EthAd
 
 	// Delete batch since it is finished
 	k.DeleteBatch(ctx, *batch)
+	// Delete it's confirmations as well
+	k.DeleteBatchConfirms(ctx, *batch)
 
 	batchEvent := sdk.NewEvent(
 		types.EventTypeOutgoingBatchCanceled,

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -412,3 +412,17 @@ func (k Keeper) IterateValsetConfirmByNonce(ctx sdk.Context, nonce uint64, cb fu
 		}
 	}
 }
+
+// DeleteValsetConfirms deletes the valset confirmations for the valset at a given nonce from state
+func (k Keeper) DeleteValsetConfirms(ctx sdk.Context, nonce uint64) {
+	store := ctx.KVStore(k.storeKey)
+	for _, confirm := range k.GetValsetConfirms(ctx, nonce) {
+		orchestrator, err := sdk.AccAddressFromBech32(confirm.Orchestrator)
+		if err == nil {
+			confirmKey := []byte(types.GetValsetConfirmKey(nonce, orchestrator))
+			if store.Has(confirmKey) {
+				store.Delete(confirmKey)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix for issue #41 includes:
- Deleting validator set confirmations from the store together with their validator sets in pruneValsets().
- Deleting batch confirmations from the store together with their batches in OutgoingTxBatchExecuted() and CancelOutgoingTXBatch()