### PR TITLE
Fix ValsetConfirm iteration

### DIFF
--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -64,11 +64,8 @@ func (k Keeper) ValsetConfirm(
 func (k Keeper) ValsetConfirmsByNonce(
 	c context.Context,
 	req *types.QueryValsetConfirmsByNonceRequest) (*types.QueryValsetConfirmsByNonceResponse, error) {
-	var confirms []types.MsgValsetConfirm
-	k.IterateValsetConfirmByNonce(sdk.UnwrapSDKContext(c), req.Nonce, func(_ []byte, c types.MsgValsetConfirm) bool {
-		confirms = append(confirms, c)
-		return false
-	})
+	confirms := k.GetValsetConfirms(sdk.UnwrapSDKContext(c), req.Nonce)
+
 	return &types.QueryValsetConfirmsByNonceResponse{Confirms: confirms}, nil
 }
 

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -373,7 +373,7 @@ func (k Keeper) SetValsetConfirm(ctx sdk.Context, valsetConf types.MsgValsetConf
 // GetValsetConfirms returns all validator set confirmations by nonce
 func (k Keeper) GetValsetConfirms(ctx sdk.Context, nonce uint64) (confirms []types.MsgValsetConfirm) {
 	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.ValsetConfirmKey))
-	start, end := prefixRange(types.UInt64Bytes(nonce))
+	start, end := prefixRange([]byte(types.ConvertByteArrToString(types.UInt64Bytes(nonce))))
 	iterator := prefixStore.Iterator(start, end)
 
 	defer iterator.Close()
@@ -390,25 +390,4 @@ func (k Keeper) GetValsetConfirms(ctx sdk.Context, nonce uint64) (confirms []typ
 	}
 
 	return confirms
-}
-
-// IterateValsetConfirmByNonce iterates through all valset confirms by validator set nonce in ASC order
-func (k Keeper) IterateValsetConfirmByNonce(ctx sdk.Context, nonce uint64, cb func([]byte, types.MsgValsetConfirm) bool) {
-	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), []byte(types.ValsetConfirmKey))
-	iter := prefixStore.Iterator(prefixRange(types.UInt64Bytes(nonce)))
-	defer iter.Close()
-
-	for ; iter.Valid(); iter.Next() {
-		confirm := types.MsgValsetConfirm{
-			Nonce:        nonce,
-			Orchestrator: "",
-			EthAddress:   "",
-			Signature:    "",
-		}
-		k.cdc.MustUnmarshal(iter.Value(), &confirm)
-		// cb returns true to stop early
-		if cb(iter.Key(), confirm) {
-			break
-		}
-	}
 }

--- a/module/x/gravity/types/key.go
+++ b/module/x/gravity/types/key.go
@@ -168,7 +168,7 @@ func GetValsetConfirmKey(nonce uint64, validator sdk.AccAddress) string {
 	if err := sdk.VerifyAddressFormat(validator); err != nil {
 		panic(sdkerrors.Wrap(err, "invalid validator address"))
 	}
-	return ValsetConfirmKey + convertByteArrToString(UInt64Bytes(nonce)) + string(validator.Bytes())
+	return ValsetConfirmKey + ConvertByteArrToString(UInt64Bytes(nonce)) + string(validator.Bytes())
 }
 
 // GetClaimKey returns the following key format
@@ -202,7 +202,7 @@ func GetClaimKey(details EthereumClaim) string {
 	copy(key[len(OracleClaimKey)+claimTypeLen:], details.GetClaimer())
 	copy(key[len(OracleClaimKey)+claimTypeLen+addrLen:], nonceBz)
 	copy(key[len(OracleClaimKey)+claimTypeLen+addrLen+len(nonceBz):], detailsHash)
-	return convertByteArrToString(key)
+	return ConvertByteArrToString(key)
 }
 
 // GetAttestationKey returns the following key format
@@ -217,7 +217,7 @@ func GetAttestationKey(eventNonce uint64, claimHash []byte) string {
 	copy(key[0:], OracleAttestationKey)
 	copy(key[len(OracleAttestationKey):], UInt64Bytes(eventNonce))
 	copy(key[len(OracleAttestationKey)+len(UInt64Bytes(0)):], claimHash)
-	return convertByteArrToString(key)
+	return ConvertByteArrToString(key)
 }
 
 // GetOutgoingTxPoolContractPrefix returns the following key format
@@ -240,7 +240,7 @@ func GetOutgoingTxPoolKey(fee InternalERC20Token, id uint64) string {
 	a := append(amount, UInt64Bytes(id)...)
 	b := append([]byte(fee.Contract.GetAddress()), a...)
 	r := append([]byte(OutgoingTXPoolKey), b...)
-	return convertByteArrToString(r)
+	return ConvertByteArrToString(r)
 }
 
 // GetOutgoingTxBatchKey returns the following key format
@@ -301,10 +301,10 @@ func GetLogicConfirmKey(invalidationId []byte, invalidationNonce uint64, validat
 // prefix    checkpoint
 // [0x0][ checkpoint bytes ]
 func GetPastEthSignatureCheckpointKey(checkpoint []byte) string {
-	return PastEthSignatureCheckpointKey + convertByteArrToString(checkpoint)
+	return PastEthSignatureCheckpointKey + ConvertByteArrToString(checkpoint)
 }
 
-func convertByteArrToString(value []byte) string {
+func ConvertByteArrToString(value []byte) string {
 	var ret strings.Builder
 	for i := 0; i < len(value); i++ {
 		ret.WriteString(string(value[i]))


### PR DESCRIPTION
The function GetValsetConfirms breaks when the validator set nonce
exceeds the value of 128. This is because types/key.go was modified to
use strings for indexing but this function was not modified to perform
the same conversion when deciding it's prefix range.

This has the unfortunate effect of halting the chain, for validator sets
greater than 128 becuase the confirms will not be successfuly located in
abci.go when valset slashing is performed. Resutling in slashing of all
the validators at the same block.

This patch corrects the issue for GetValsetConfirm by stringifying the
nonce in the same way as types/key.go

But the existance of this issue highlights a larger need to further
restructure key.go to provide prefixed keys so that modifications are
more localized and the addition of more unit tests related to getters
and setters.

I have found IterateLogicConfirmByInvalidationIDAndNonce suffers from
the same issue and generally question the existance of
ConvertByteArrToString in key.go.