### PR TITLE
Modfiy geth config to allow remote requests

### DIFF
--- a/tests/container-scripts/run-eth.sh
+++ b/tests/container-scripts/run-eth.sh
@@ -12,6 +12,7 @@ geth --identity "GravityTestnet" --nodiscover \
 --networkid 15 \
 --mine \
 --http \
+--http.corsdomain="*" \
 --miner.threads=1 \
 --nousb \
 --verbosity=5 \

--- a/tests/container-scripts/run-eth.sh
+++ b/tests/container-scripts/run-eth.sh
@@ -11,7 +11,7 @@ geth --identity "GravityTestnet" \
 geth --identity "GravityTestnet" --nodiscover \
 --networkid 15 \
 --mine \
---http \
+--http "0.0.0.0" \
 --http.corsdomain="*" \
 --miner.threads=1 \
 --nousb \

--- a/tests/container-scripts/run-eth.sh
+++ b/tests/container-scripts/run-eth.sh
@@ -11,7 +11,9 @@ geth --identity "GravityTestnet" \
 geth --identity "GravityTestnet" --nodiscover \
 --networkid 15 \
 --mine \
---http "0.0.0.0" \
+--http \
+--http.addr="0.0.0.0" \
+--http.vhosts="*" \
 --http.corsdomain="*" \
 --miner.threads=1 \
 --nousb \


### PR DESCRIPTION
Since we're using our development environment as a mini testnet this is
required so that frontends can make requests to the server without
violating cors.

This may have some security implications but only when the test environment is run on a machine that has no firewall, considering the normal case for this is a developer who needs more remote processing power exposing the endpoints seems like a good thing to ease development. 