### PR TITLE
Gravity cli panics when calling send-to-eth #68-fix

### DIFF
--- a/module/x/gravity/client/cli/query.go
+++ b/module/x/gravity/client/cli/query.go
@@ -121,8 +121,8 @@ func CmdGetValsetConfirm() *cobra.Command {
 func CmdGetPendingValsetRequest() *cobra.Command {
 	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
-		Use:   "pending-valset-request [bech32 validator address]",
-		Short: "Get the latest valset request which has not been signed by a particular validator",
+		Use:   "pending-valset-request [bech32 orchestrator address]",
+		Short: "Get the latest valset request which has not been signed by a particular orchestrator",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)
@@ -147,8 +147,8 @@ func CmdGetPendingValsetRequest() *cobra.Command {
 func CmdGetPendingOutgoingTXBatchRequest() *cobra.Command {
 	//nolint: exhaustivestruct
 	cmd := &cobra.Command{
-		Use:   "pending-batch-request [bech32 validator address]",
-		Short: "Get the latest outgoing TX batch request which has not been signed by a particular validator",
+		Use:   "pending-batch-request [bech32 orchestrator address]",
+		Short: "Get the latest outgoing TX batch request which has not been signed by a particular orchestrator",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx := client.GetClientContextFromCmd(cmd)

--- a/module/x/gravity/client/cli/tx.go
+++ b/module/x/gravity/client/cli/tx.go
@@ -64,8 +64,8 @@ func CmdGovIbcMetadataProposal() *cobra.Command {
 				return sdkerrors.Wrap(err, "bad initial deposit amount")
 			}
 
-			if len(initialDeposit) > 1 {
-				return fmt.Errorf("coin amounts too long, expecting just 1 coin amount for both amount and bridgeFee")
+			if len(initialDeposit) != 1 {
+				return fmt.Errorf("unexpected coin amounts, expecting just 1 coin amount for initialDeposit")
 			}
 
 			proposalFile := args[0]
@@ -141,8 +141,8 @@ func CmdGovAirdropProposal() *cobra.Command {
 				return sdkerrors.Wrap(err, "bad initial deposit amount")
 			}
 
-			if len(initialDeposit) > 1 {
-				return fmt.Errorf("coin amounts too long, expecting just 1 coin amount for both amount and bridgeFee")
+			if len(initialDeposit) != 1 {
+				return fmt.Errorf("unexpected coin amounts, expecting just 1 coin amount for initialDeposit")
 			}
 
 			proposalFile := args[0]
@@ -220,8 +220,8 @@ func CmdGovUnhaltBridgeProposal() *cobra.Command {
 				return sdkerrors.Wrap(err, "bad initial deposit amount")
 			}
 
-			if len(initialDeposit) > 1 {
-				return fmt.Errorf("coin amounts too long, expecting just 1 coin amount for both amount and bridgeFee")
+			if len(initialDeposit) != 1 {
+				return fmt.Errorf("unexpected coin amounts, expecting just 1 coin amount for initialDeposit")
 			}
 
 			proposalFile := args[0]
@@ -286,8 +286,8 @@ func CmdSendToEth() *cobra.Command {
 				return sdkerrors.Wrap(err, "invalid eth address")
 			}
 
-			if len(amount) > 1 || len(bridgeFee) > 1 {
-				return fmt.Errorf("coin amounts too long, expecting just 1 coin amount for both amount and bridgeFee")
+			if len(amount) != 1 || len(bridgeFee) != 1 {
+				return fmt.Errorf("unexpected coin amounts, expecting just 1 coin amount for both amount and bridgeFee")
 			}
 
 			// Make the message

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -304,7 +304,7 @@ pub async fn eth_signer_main_loop(
                     trace!("No validator sets to sign, node is caught up!")
                 } else {
                     info!(
-                        "Sending {} valset confirms starting with {}",
+                        "Sending {} valset confirms starting with nonce {}",
                         valsets.len(),
                         valsets[0].nonce
                     );
@@ -340,7 +340,7 @@ pub async fn eth_signer_main_loop(
                     trace!("No unsigned batch sets to sign, node is caught up!")
                 } else {
                     info!(
-                        "Sending {} valset confirms starting with {}",
+                        "Sending {} batch confirms starting with nonce {}",
                         last_unsigned_batches.len(),
                         last_unsigned_batches[0].nonce
                     );
@@ -376,7 +376,7 @@ pub async fn eth_signer_main_loop(
                     trace!("No unsigned call sets to sign, node is caught up!")
                 } else {
                     info!(
-                        "Sending {} valset confirms starting with {}",
+                        "Sending {} logic call confirms starting with nonce {}",
                         last_unsigned_calls.len(),
                         last_unsigned_calls[0].invalidation_nonce
                     );


### PR DESCRIPTION
Fix for issue #68 
I also fixed incorrect orchestrator logs for valset, batch and logic calls.
And help message when using gravity q gravity pending-batch-request/pending-valset-requests (now shows "orchestrator address" instead of "validator address").