### PR TITLE
First AnteHandler PR: add ibc-go antedecorator to sdk antehandler

### DIFF
--- a/module/app/ante.go
+++ b/module/app/ante.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	channelkeeper "github.com/cosmos/ibc-go/v2/modules/core/04-channel/keeper"
+	ibcante "github.com/cosmos/ibc-go/v2/modules/core/ante"
+)
+
+// Constructs a new sdk.AnteHandler for the Gravity app.
+// AnteHandlers are functions which validate Txs before their contained Msgs are executed, AnteHandlers are constructed
+// from a chain of AnteDecorators, the final AnteDecorator in the chain being ante.Terminator.
+// This custom AnteHandler constructor loosely chains together the pre-Terminator-ed default sdk AnteHandler
+// with additional AnteDecorators. This complicated process is desirable because:
+//   1. the default sdk AnteHandler can change on any upgrade (so we do not want to have a stale list of AnteDecorators),
+//   2. it is not possible to modify an AnteHandler once it is constructed
+func newAnteHandler(options ante.HandlerOptions, ibcChannelKeeper channelkeeper.Keeper) (*sdk.AnteHandler, error) {
+	// Call the default sdk antehandler constructor to avoid auditing our changes in the future
+	baseAnteHandler, err := ante.NewAnteHandler(options)
+	if err != nil {
+		return nil, sdkerrors.Wrap(err, "Unable to create baseAnteHanlder")
+	}
+
+	// Create additional AnteDecorators to chain together
+	ibcAnteDecorator := ibcante.NewAnteDecorator(ibcChannelKeeper)
+	addlDecorators := []sdk.AnteDecorator{ibcAnteDecorator}
+	// Chain together and terminate the input decorators array
+	customHandler := sdk.ChainAnteDecorators(addlDecorators...)
+
+	// Create and return a function which ties the two handlers together
+	fullHandler := addDecoratorsToHandler(baseAnteHandler, customHandler)
+	return &fullHandler, nil
+}
+
+// Loosely chain together two AnteHandlers by first calling handler, then calling secondHandler with the result
+// This is necessary because AnteHandlers are immutable once constructed, and the sdk does not expose its curated list
+// of default AnteDecorators.
+func addDecoratorsToHandler(handler sdk.AnteHandler, secondHandler sdk.AnteHandler) sdk.AnteHandler {
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		// First run the original AnteHandler (likely the default sdk chain of decorators)
+		newCtx, err := handler(ctx, tx, simulate)
+		if err != nil { // Return early from an error
+			return newCtx, err
+		}
+
+		// Next run the second handler
+		return secondHandler(newCtx, tx, simulate)
+	}
+}

--- a/module/app/app.go
+++ b/module/app/app.go
@@ -653,6 +653,7 @@ func NewGravityApp(
 
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
+
 	options := ante.HandlerOptions{
 		AccountKeeper:   accountKeeper,
 		BankKeeper:      bankKeeper,
@@ -660,11 +661,13 @@ func NewGravityApp(
 		SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 		SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 	}
-	ah, err := ante.NewAnteHandler(options)
+
+	ah, err := newAnteHandler(options, ibcKeeper.ChannelKeeper)
 	if err != nil {
 		panic("invalid antehandler created")
 	}
-	app.SetAnteHandler(ah)
+	app.SetAnteHandler(*ah)
+
 	app.SetEndBlocker(app.EndBlocker)
 
 	if loadLatest {

--- a/module/app/app.go
+++ b/module/app/app.go
@@ -218,33 +218,75 @@ type Gravity struct {
 
 // ValidateMembers checks for nil members
 func (app Gravity) ValidateMembers() {
-	if app.legacyAmino == nil { panic("Nil legacyAmino!") }
+	if app.legacyAmino == nil {
+		panic("Nil legacyAmino!")
+	}
 
 	// keepers
-	if app.accountKeeper     == nil { panic("Nil accountKeeper!") }
-	if app.authzKeeper       == nil { panic("Nil authzKeeper!") }
-	if app.bankKeeper        == nil { panic("Nil bankKeeper!") }
-	if app.capabilityKeeper  == nil { panic("Nil capabilityKeeper!") }
-	if app.stakingKeeper     == nil { panic("Nil stakingKeeper!") }
-	if app.slashingKeeper    == nil { panic("Nil slashingKeeper!") }
-	if app.mintKeeper        == nil { panic("Nil mintKeeper!") }
-	if app.distrKeeper       == nil { panic("Nil distrKeeper!") }
-	if app.govKeeper         == nil { panic("Nil govKeeper!") }
-	if app.crisisKeeper      == nil { panic("Nil crisisKeeper!") }
-	if app.upgradeKeeper     == nil { panic("Nil upgradeKeeper!") }
-	if app.paramsKeeper      == nil { panic("Nil paramsKeeper!") }
-	if app.ibcKeeper         == nil { panic("Nil ibcKeeper!") }
-	if app.evidenceKeeper    == nil { panic("Nil evidenceKeeper!") }
-	if app.ibcTransferKeeper == nil { panic("Nil ibcTransferKeeper!") }
-	if app.gravityKeeper     == nil { panic("Nil gravityKeeper!") }
+	if app.accountKeeper == nil {
+		panic("Nil accountKeeper!")
+	}
+	if app.authzKeeper == nil {
+		panic("Nil authzKeeper!")
+	}
+	if app.bankKeeper == nil {
+		panic("Nil bankKeeper!")
+	}
+	if app.capabilityKeeper == nil {
+		panic("Nil capabilityKeeper!")
+	}
+	if app.stakingKeeper == nil {
+		panic("Nil stakingKeeper!")
+	}
+	if app.slashingKeeper == nil {
+		panic("Nil slashingKeeper!")
+	}
+	if app.mintKeeper == nil {
+		panic("Nil mintKeeper!")
+	}
+	if app.distrKeeper == nil {
+		panic("Nil distrKeeper!")
+	}
+	if app.govKeeper == nil {
+		panic("Nil govKeeper!")
+	}
+	if app.crisisKeeper == nil {
+		panic("Nil crisisKeeper!")
+	}
+	if app.upgradeKeeper == nil {
+		panic("Nil upgradeKeeper!")
+	}
+	if app.paramsKeeper == nil {
+		panic("Nil paramsKeeper!")
+	}
+	if app.ibcKeeper == nil {
+		panic("Nil ibcKeeper!")
+	}
+	if app.evidenceKeeper == nil {
+		panic("Nil evidenceKeeper!")
+	}
+	if app.ibcTransferKeeper == nil {
+		panic("Nil ibcTransferKeeper!")
+	}
+	if app.gravityKeeper == nil {
+		panic("Nil gravityKeeper!")
+	}
 
 	// scoped keepers
-	if app.ScopedIBCKeeper      == nil { panic("Nil ScopedIBCKeeper!") }
-	if app.ScopedTransferKeeper == nil { panic("Nil ScopedTransferKeeper!") }
+	if app.ScopedIBCKeeper == nil {
+		panic("Nil ScopedIBCKeeper!")
+	}
+	if app.ScopedTransferKeeper == nil {
+		panic("Nil ScopedTransferKeeper!")
+	}
 
 	// managers
-	if app.mm == nil { panic("Nil ModuleManager!") }
-	if app.sm == nil { panic("Nil ModuleManager!") }
+	if app.mm == nil {
+		panic("Nil ModuleManager!")
+	}
+	if app.sm == nil {
+		panic("Nil ModuleManager!")
+	}
 }
 
 func init() {


### PR DESCRIPTION
This PR performs a little trick to make sure we keep up with any cosmos-sdk antehandler changes while still preserving our ability to chain additional antedecorators after the cosmos-sdk antehandler runs. This way we don't need to artisanally prune a thoroughly confusing chain of antedecorators by hand, we can just upgrade the SDK with slightly less headache.