### PR TITLE
Prevent spurious warning when auto-requesting batches

### DIFF
--- a/orchestrator/relayer/src/request_batches.rs
+++ b/orchestrator/relayer/src/request_batches.rs
@@ -78,7 +78,11 @@ pub async fn request_batches(
                             )
                             .await;
                             if let Err(e) = res {
-                                warn!("Failed to request batch with {:?}", e);
+                                if e.to_string().contains("would not be more profitable") {
+                                    info!("Batch would not have been more profitable, no new batch created");
+                                } else {
+                                    warn!("Failed to request batch with {:?}", e);
+                                }
                             }
                         } else {
                             trace!("Did not request unprofitable batch");


### PR DESCRIPTION
This patch adds a check for when the auto batch request tx fails becuase
the new batch would not be more proftiable. This is intended behavior
and our profitability check does not take this into account.

When the orchestrator decides to request a batch it only checks if there
are any transactions with fees in the tx pool. It does not check if
there is already a more profitable batch of this type waiting. But the
actual batch creation logic does perform this check to prevent the spam
creation of batches.

Since it's free to make this mistake (tx fails in simulation) we can
simply catch the error and mute it rather than expanding the
orchestrator logic to match the internal batch creation logic.