### PR TITLE
fix: accept confirms only from bonded or unbonding validators

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -196,11 +196,12 @@ func prepValsetConfirms(ctx sdk.Context, k keeper.Keeper, nonce uint64) map[stri
 		if err != nil {
 			panic("Invalid confirm in store")
 		}
-		val, foundValidator := k.GetOrchestratorValidator(ctx, confVal)
+		val, foundValidator := k.GetOrchestratorValidatorAddr(ctx, confVal)
 		if !foundValidator {
+			// This means that the validator never sent a SetOrchestratorAddress message.
 			panic("Confirm from validator we can't identify?")
 		}
-		ret[val.GetOperator().String()] = confirm
+		ret[val.String()] = confirm
 	}
 	return ret
 }
@@ -344,11 +345,12 @@ func prepBatchConfirms(ctx sdk.Context, k keeper.Keeper, batch types.InternalOut
 		if err != nil {
 			panic(err)
 		}
-		val, foundValidator := k.GetOrchestratorValidator(ctx, confVal)
+		val, foundValidator := k.GetOrchestratorValidatorAddr(ctx, confVal)
 		if !foundValidator {
+			// This means that the validator never sent a SetOrchestratorAddress message.
 			panic("Confirm from validator we can't identify?")
 		}
-		ret[val.GetOperator().String()] = confirm
+		ret[val.String()] = confirm
 	}
 	return ret
 }
@@ -421,11 +423,12 @@ func prepLogicCallConfirms(ctx sdk.Context, k keeper.Keeper, call types.Outgoing
 		if err != nil {
 			panic(err)
 		}
-		val, foundValidator := k.GetOrchestratorValidator(ctx, confVal)
+		val, foundValidator := k.GetOrchestratorValidatorAddr(ctx, confVal)
 		if !foundValidator {
+			// This means that the validator never sent a SetOrchestratorAddress message.
 			panic("Confirm from validator we can't identify?")
 		}
-		ret[val.GetOperator().String()] = &confirm
+		ret[val.String()] = &confirm
 	}
 	return ret
 }

--- a/module/x/gravity/keeper/keeper_delegate_key.go
+++ b/module/x/gravity/keeper/keeper_delegate_key.go
@@ -30,13 +30,13 @@ func (k Keeper) SetOrchestratorValidator(ctx sdk.Context, val sdk.ValAddress, or
 
 // GetOrchestratorValidator returns the validator key associated with an orchestrator key
 func (k Keeper) GetOrchestratorValidator(ctx sdk.Context, orch sdk.AccAddress) (validator stakingtypes.Validator, found bool) {
+	valAddr, foundValAddr := k.GetOrchestratorValidatorAddr(ctx, orch)
 	if err := sdk.VerifyAddressFormat(orch); err != nil {
 		ctx.Logger().Error("invalid orch address")
 		return validator, false
 	}
-	store := ctx.KVStore(k.storeKey)
-	valAddr := store.Get([]byte(types.GetOrchestratorAddressKey(orch)))
-	if valAddr == nil {
+
+	if !foundValAddr && valAddr == nil {
 		return stakingtypes.Validator{
 			OperatorAddress: "",
 			ConsensusPubkey: &codectypes.Any{

--- a/module/x/gravity/keeper/keeper_delegate_key.go
+++ b/module/x/gravity/keeper/keeper_delegate_key.go
@@ -109,6 +109,23 @@ func (k Keeper) GetOrchestratorValidator(ctx sdk.Context, orch sdk.AccAddress) (
 	return validator, true
 }
 
+// GetOrchestratorValidatorAddr returns the validator address associated with an orchestrator key.
+// Getting a result from this function means that the validator existed at some point and sent a SetOrchestratorAddress
+// message. It does not mean that the validator is in the current validator set, for that use GetOrchestratorValidator.
+// This will hold true as long as we never delete any delegate keys.
+func (k Keeper) GetOrchestratorValidatorAddr(ctx sdk.Context, orch sdk.AccAddress) (validator sdk.ValAddress, found bool) {
+	if err := sdk.VerifyAddressFormat(orch); err != nil {
+		ctx.Logger().Error("invalid orch address")
+		return validator, false
+	}
+	store := ctx.KVStore(k.storeKey)
+	valAddr := store.Get([]byte(types.GetOrchestratorAddressKey(orch)))
+	if valAddr == nil {
+		return sdk.ValAddress{}, false
+	}
+	return valAddr, true
+}
+
 /////////////////////////////
 //       ETH ADDRESS       //
 /////////////////////////////


### PR DESCRIPTION
This PR addresses 2 issues:

~- ETH addresses are now required to be checksummed (these means all ETH addresses). This might be an issue for already running chains if relayers don't send all of the addresses in the compliant format.~

~@jkilpatr this might be a change too drastic if there are any eth addresses in the store that aren't well-formatted, I think we are good on Umee's side because we use geth's common package for addresses. This might also break some of your shell tests~

- Accept confirms only from bonded or unbonding validators

- Don't panic when prepping the confirms for slashing if it can't find a validator

These last 2 are in the first 2 commits if you want to check them with less background noise.

EDIT: Removed Eth address related changes to make a better fix in a separate PR