### PR TITLE
feat: Use geth address instead of string

### DIFF
--- a/module/x/gravity/abci_test.go
+++ b/module/x/gravity/abci_test.go
@@ -359,7 +359,7 @@ func TestNonValidatorBatchConfirm(t *testing.T) {
 	pk.SetBatchConfirm(ctx, &types.MsgConfirmBatch{
 		Nonce:         batch.BatchNonce,
 		TokenContract: keeper.TokenContractAddrs[0],
-		EthSigner:     ethAddr.GetAddress(),
+		EthSigner:     ethAddr.GetAddress().Hex(),
 		Orchestrator:  accAddr.String(),
 		Signature:     "",
 	})
@@ -551,8 +551,8 @@ func TestBatchTimeout(t *testing.T) {
 
 		conf := &types.MsgConfirmBatch{
 			Nonce:         b2.BatchNonce,
-			TokenContract: b2.TokenContract.GetAddress(),
-			EthSigner:     ethAddr.GetAddress(),
+			TokenContract: b2.TokenContract.GetAddress().Hex(),
+			EthSigner:     ethAddr.GetAddress().Hex(),
 			Orchestrator:  orch.String(),
 			Signature:     "dummysig",
 		}

--- a/module/x/gravity/client/cli/tx.go
+++ b/module/x/gravity/client/cli/tx.go
@@ -293,7 +293,7 @@ func CmdSendToEth() *cobra.Command {
 			// Make the message
 			msg := types.MsgSendToEth{
 				Sender:    cosmosAddr.String(),
-				EthDest:   ethAddr.GetAddress(),
+				EthDest:   ethAddr.GetAddress().Hex(),
 				Amount:    amount[0],
 				BridgeFee: bridgeFee[0],
 			}

--- a/module/x/gravity/cosmos-originated_test.go
+++ b/module/x/gravity/cosmos-originated_test.go
@@ -47,7 +47,7 @@ func initializeTestingVars(t *testing.T) *testingVars {
 
 	tv.t = t
 
-	tv.erc20 = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+	tv.erc20 = "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
 	tv.denom = "ugraviton"
 
 	tv.input, tv.ctx = keeper.SetupFiveValChain(t)
@@ -109,7 +109,7 @@ func addDenomToERC20Relation(tv *testingVars) {
 	assert.True(tv.t, isCosmosOriginated)
 
 	assert.Equal(tv.t, tv.denom, gotDenom)
-	assert.Equal(tv.t, tv.erc20, gotERC20.GetAddress())
+	assert.Equal(tv.t, tv.erc20, gotERC20.GetAddress().Hex())
 }
 
 func lockCoinsInModule(tv *testingVars) {
@@ -265,5 +265,5 @@ func addIbcDenomToERC20Relation(tv *testingVars) {
 	assert.True(tv.t, isCosmosOriginated)
 
 	assert.Equal(tv.t, tv.denom, gotDenom)
-	assert.Equal(tv.t, tv.erc20, gotERC20.GetAddress())
+	assert.Equal(tv.t, tv.erc20, gotERC20.GetAddress().Hex())
 }

--- a/module/x/gravity/handler_test.go
+++ b/module/x/gravity/handler_test.go
@@ -22,7 +22,7 @@ func TestHandleMsgSendToEth(t *testing.T) {
 		userCosmosAddr, _                = sdk.AccAddressFromBech32("gravity1990z7dqsvh8gthw9pa5sn4wuy2xrsd80lcx6lv")
 		blockTime                        = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 		blockHeight            int64     = 200
-		denom                            = "gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+		denom                            = "gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
 		startingCoinAmount, _            = sdk.NewIntFromString("150000000000000000000") // 150 ETH worth, required to reach above u64 limit (which is about 18 ETH)
 		sendAmount, _                    = sdk.NewIntFromString("50000000000000000000")  // 50 ETH
 		feeAmount, _                     = sdk.NewIntFromString("5000000000000000000")   // 5 ETH
@@ -150,7 +150,7 @@ func TestMsgSendToCosmosClaim(t *testing.T) {
 
 	// and vouchers added to the account
 	balance := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountA)}, balance)
+	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e", amountA)}, balance)
 
 	// send attestations from all five validators
 	for _, v := range keeper.OrchAddrs {
@@ -173,7 +173,7 @@ func TestMsgSendToCosmosClaim(t *testing.T) {
 	}
 
 	balance = input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountA)}, balance)
+	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e", amountA)}, balance)
 
 	// send attestations from all five validators
 	for _, v := range keeper.OrchAddrs {
@@ -197,7 +197,7 @@ func TestMsgSendToCosmosClaim(t *testing.T) {
 	}
 
 	balance = input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", amountB)}, balance)
+	assert.Equal(t, sdk.Coins{sdk.NewCoin("gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e", amountB)}, balance)
 }
 
 //nolint: exhaustivestruct
@@ -206,7 +206,7 @@ func TestEthereumBlacklist(t *testing.T) {
 		myCosmosAddr, _ = sdk.AccAddressFromBech32("gravity16ahjkfqxpp6lvfy9fpfnfjg39xr96qet0l08hu")
 		anyETHSender    = "0xf9613b532673Cc223aBa451dFA8539B87e1F666D"
 		tokenETHAddr    = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
-		denom           = "gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
+		denom           = "gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e"
 		myBlockTime     = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 		amountA, _      = sdk.NewIntFromString("50000000000000000000") // 50 ETH
 	)
@@ -304,7 +304,7 @@ func TestMsgSendToCosmosOverflow(t *testing.T) {
 		myNonce             = uint64(1)
 		anyETHAddr          = "0xf9613b532673Cc223aBa451dFA8539B87e1F666D"
 		tokenETHAddr1       = "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e"
-		tokenETHAddr2       = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6"
+		tokenETHAddr2       = "0x429881672b9AE42b8eBA0e26cd9c73711b891ca6"
 		myBlockTime         = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
 		tokenEthAddress1, _ = types.NewEthAddress(tokenETHAddr1)
 		tokenEthAddress2, _ = types.NewEthAddress(tokenETHAddr2)
@@ -439,7 +439,7 @@ func TestMsgSendToCosmosClaimSpreadVotes(t *testing.T) {
 		require.NotNil(t, a1)
 		// and vouchers not yet added to the account
 		balance1 := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-		assert.NotEqual(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance1)
+		assert.NotEqual(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e", 12)}, balance1)
 	}
 
 	// when
@@ -456,7 +456,7 @@ func TestMsgSendToCosmosClaimSpreadVotes(t *testing.T) {
 	require.NotNil(t, a2)
 	// and vouchers now added to the account
 	balance2 := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	assert.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance2)
+	assert.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e", 12)}, balance2)
 
 	// when
 	ctx = ctx.WithBlockTime(myBlockTime)
@@ -472,7 +472,7 @@ func TestMsgSendToCosmosClaimSpreadVotes(t *testing.T) {
 	require.NotNil(t, a3)
 	// and no additional added to the account
 	balance3 := input.BankKeeper.GetAllBalances(ctx, myCosmosAddr)
-	assert.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e", 12)}, balance3)
+	assert.Equal(t, sdk.Coins{sdk.NewInt64Coin("gravity0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e", 12)}, balance3)
 }
 
 // Tests sending funds to a native account and to that same account with a foreign prefix
@@ -589,7 +589,7 @@ func TestMsgSetOrchestratorAddresses(t *testing.T) {
 	require.NoError(t, err)
 
 	queryE := types.QueryDelegateKeysByEthAddress{
-		EthAddress: ethAddress.GetAddress(),
+		EthAddress: ethAddress.GetAddress().Hex(),
 	}
 	_, err = k.GetDelegateKeyByEth(wctx, &queryE)
 	require.NoError(t, err)

--- a/module/x/gravity/keeper/attestation.go
+++ b/module/x/gravity/keeper/attestation.go
@@ -151,7 +151,7 @@ func (k Keeper) emitObservedEvent(ctx sdk.Context, att *types.Attestation, claim
 	ctx.EventManager().EmitTypedEvent(
 		&types.EventObservation{
 			AttestationType: string(claim.GetType()),
-			BridgeContract:  k.GetBridgeContractAddress(ctx).GetAddress(),
+			BridgeContract:  k.GetBridgeContractAddress(ctx).GetAddress().Hex(),
 			BridgeChainId:   strconv.Itoa(int(k.GetBridgeChainID(ctx))),
 			AttestationId:   string(types.GetAttestationKey(claim.GetEventNonce(), hash)),
 			Nonce:           fmt.Sprint(claim.GetEventNonce()),

--- a/module/x/gravity/keeper/attestation_handler.go
+++ b/module/x/gravity/keeper/attestation_handler.go
@@ -168,7 +168,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 				&types.EventInvalidSendToCosmosReceiver{
 					Amount: claim.Amount.String(),
 					Nonce:  strconv.Itoa(int(claim.GetEventNonce())),
-					Token:  tokenAddress.GetAddress(),
+					Token:  tokenAddress.GetAddress().Hex(),
 					Sender: claim.EthereumSender,
 				},
 			)
@@ -178,7 +178,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 				&types.EventSendToCosmos{
 					Amount: claim.Amount.String(),
 					Nonce:  strconv.Itoa(int(claim.GetEventNonce())),
-					Token:  tokenAddress.GetAddress(),
+					Token:  tokenAddress.GetAddress().Hex(),
 				},
 			)
 		}
@@ -207,7 +207,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 		if exists {
 			return sdkerrors.Wrap(
 				types.ErrInvalid,
-				fmt.Sprintf("ERC20 %s already exists for denom %s", existingERC20, claim.CosmosDenom))
+				fmt.Sprintf("ERC20 %s already exists for denom %s", existingERC20.GetAddress().Hex(), claim.CosmosDenom))
 		}
 
 		// Check if denom exists
@@ -261,7 +261,7 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 
 		ctx.EventManager().EmitTypedEvent(
 			&types.EventERC20DeployedClaim{
-				Token: tokenAddress.GetAddress(),
+				Token: tokenAddress.GetAddress().Hex(),
 				Nonce: strconv.Itoa(int(claim.GetEventNonce())),
 			},
 		)

--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -24,7 +24,7 @@ func TestBatches(t *testing.T) {
 		mySender, _            = sdk.AccAddressFromBech32("gravity1ahx7f8wyertuus9r20284ej0asrs085ceqtfnm")
 		myReceiver, _          = types.NewEthAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr, _ = types.NewEthAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
-		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress())
+		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress().Hex())
 		allVouchers            = sdk.NewCoins(token.GravityCoin())
 	)
 	require.NoError(t, err)
@@ -45,10 +45,10 @@ func TestBatches(t *testing.T) {
 
 	// add some TX to the pool
 	for i, v := range []uint64{2, 3, 2, 1} {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress())
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
@@ -85,26 +85,26 @@ func TestBatches(t *testing.T) {
 		Transactions: []types.OutgoingTransferTx{
 			{
 				Id:          2,
-				Erc20Fee:    types.NewERC20Token(3, myTokenContractAddr.GetAddress()),
+				Erc20Fee:    types.NewERC20Token(3, myTokenContractAddr.GetAddress().Hex()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver.GetAddress(),
-				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr.GetAddress()),
+				DestAddress: myReceiver.GetAddress().Hex(),
+				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr.GetAddress().Hex()),
 			},
 			{
 				Id:          3,
-				Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr.GetAddress()),
+				Erc20Fee:    types.NewERC20Token(2, myTokenContractAddr.GetAddress().Hex()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver.GetAddress(),
-				Erc20Token:  types.NewERC20Token(102, myTokenContractAddr.GetAddress()),
+				DestAddress: myReceiver.GetAddress().Hex(),
+				Erc20Token:  types.NewERC20Token(102, myTokenContractAddr.GetAddress().Hex()),
 			},
 		},
-		TokenContract: myTokenContractAddr.GetAddress(),
+		TokenContract: myTokenContractAddr.GetAddress().Hex(),
 		Block:         1234567,
 	}
 	assert.Equal(t, expFirstBatch.BatchTimeout, gotFirstBatch.BatchTimeout)
 	assert.Equal(t, expFirstBatch.BatchNonce, gotFirstBatch.BatchNonce)
 	assert.Equal(t, expFirstBatch.Block, gotFirstBatch.Block)
-	assert.Equal(t, expFirstBatch.TokenContract, gotFirstBatch.TokenContract.GetAddress())
+	assert.Equal(t, expFirstBatch.TokenContract, gotFirstBatch.TokenContract.GetAddress().Hex())
 	assert.Equal(t, len(expFirstBatch.Transactions), len(gotFirstBatch.Transactions))
 	for i := 0; i < len(expFirstBatch.Transactions); i++ {
 		assert.Equal(t, expFirstBatch.Transactions[i], gotFirstBatch.Transactions[i].ToExternal())
@@ -117,8 +117,8 @@ func TestBatches(t *testing.T) {
 
 		conf := &types.MsgConfirmBatch{
 			Nonce:         firstBatch.BatchNonce,
-			TokenContract: firstBatch.TokenContract.GetAddress(),
-			EthSigner:     ethAddr.GetAddress(),
+			TokenContract: firstBatch.TokenContract.GetAddress().Hex(),
+			EthSigner:     ethAddr.GetAddress().Hex(),
 			Orchestrator:  orch.String(),
 			Signature:     "dummysig",
 		}
@@ -133,10 +133,10 @@ func TestBatches(t *testing.T) {
 	// and verify remaining available Tx in the pool
 	// Should still have 1: and 4: above
 	gotUnbatchedTx := input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, *myTokenContractAddr)
-	oneFee, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr.GetAddress())
-	oneHundredTok, _ := types.NewInternalERC20Token(sdk.NewInt(100), myTokenContractAddr.GetAddress())
-	twoFee, _ := types.NewInternalERC20Token(sdk.NewInt(2), myTokenContractAddr.GetAddress())
-	oneHundredThreeTok, _ := types.NewInternalERC20Token(sdk.NewInt(103), myTokenContractAddr.GetAddress())
+	oneFee, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr.GetAddress().Hex())
+	oneHundredTok, _ := types.NewInternalERC20Token(sdk.NewInt(100), myTokenContractAddr.GetAddress().Hex())
+	twoFee, _ := types.NewInternalERC20Token(sdk.NewInt(2), myTokenContractAddr.GetAddress().Hex())
+	oneHundredThreeTok, _ := types.NewInternalERC20Token(sdk.NewInt(103), myTokenContractAddr.GetAddress().Hex())
 	expUnbatchedTx := []*types.InternalOutgoingTransferTx{
 		{
 			Id:          1,
@@ -165,10 +165,10 @@ func TestBatches(t *testing.T) {
 
 	// add some more TX to the pool to create a more profitable batch
 	for i, v := range []uint64{4, 5} {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress())
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
@@ -192,27 +192,27 @@ func TestBatches(t *testing.T) {
 		Transactions: []types.OutgoingTransferTx{
 			{
 				Id:          6,
-				Erc20Fee:    types.NewERC20Token(5, myTokenContractAddr.GetAddress()),
+				Erc20Fee:    types.NewERC20Token(5, myTokenContractAddr.GetAddress().Hex()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver.GetAddress(),
-				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr.GetAddress()),
+				DestAddress: myReceiver.GetAddress().Hex(),
+				Erc20Token:  types.NewERC20Token(101, myTokenContractAddr.GetAddress().Hex()),
 			},
 			{
 				Id:          5,
-				Erc20Fee:    types.NewERC20Token(4, myTokenContractAddr.GetAddress()),
+				Erc20Fee:    types.NewERC20Token(4, myTokenContractAddr.GetAddress().Hex()),
 				Sender:      mySender.String(),
-				DestAddress: myReceiver.GetAddress(),
-				Erc20Token:  types.NewERC20Token(100, myTokenContractAddr.GetAddress()),
+				DestAddress: myReceiver.GetAddress().Hex(),
+				Erc20Token:  types.NewERC20Token(100, myTokenContractAddr.GetAddress().Hex()),
 			},
 		},
-		TokenContract: myTokenContractAddr.GetAddress(),
+		TokenContract: myTokenContractAddr.GetAddress().Hex(),
 		Block:         1234567,
 	}
 
 	assert.Equal(t, expSecondBatch.BatchTimeout, secondBatch.BatchTimeout)
 	assert.Equal(t, expSecondBatch.BatchNonce, secondBatch.BatchNonce)
 	assert.Equal(t, expSecondBatch.Block, secondBatch.Block)
-	assert.Equal(t, expSecondBatch.TokenContract, secondBatch.TokenContract.GetAddress())
+	assert.Equal(t, expSecondBatch.TokenContract, secondBatch.TokenContract.GetAddress().Hex())
 	assert.Equal(t, len(expSecondBatch.Transactions), len(secondBatch.Transactions))
 	for i := 0; i < len(expSecondBatch.Transactions); i++ {
 		assert.Equal(t, expSecondBatch.Transactions[i], secondBatch.Transactions[i].ToExternal())
@@ -225,8 +225,8 @@ func TestBatches(t *testing.T) {
 
 		conf := &types.MsgConfirmBatch{
 			Nonce:         secondBatch.BatchNonce,
-			TokenContract: secondBatch.TokenContract.GetAddress(),
-			EthSigner:     ethAddr.GetAddress(),
+			TokenContract: secondBatch.TokenContract.GetAddress().Hex(),
+			EthSigner:     ethAddr.GetAddress().Hex(),
 			Orchestrator:  orch.String(),
 			Signature:     "dummysig",
 		}
@@ -258,9 +258,9 @@ func TestBatches(t *testing.T) {
 
 	// check that txs from first batch have been freed
 	gotUnbatchedTx = input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, *myTokenContractAddr)
-	threeFee, _ := types.NewInternalERC20Token(sdk.NewInt(3), myTokenContractAddr.GetAddress())
-	oneHundredOneTok, _ := types.NewInternalERC20Token(sdk.NewInt(101), myTokenContractAddr.GetAddress())
-	oneHundredTwoTok, _ := types.NewInternalERC20Token(sdk.NewInt(102), myTokenContractAddr.GetAddress())
+	threeFee, _ := types.NewInternalERC20Token(sdk.NewInt(3), myTokenContractAddr.GetAddress().Hex())
+	oneHundredOneTok, _ := types.NewInternalERC20Token(sdk.NewInt(101), myTokenContractAddr.GetAddress().Hex())
+	oneHundredTwoTok, _ := types.NewInternalERC20Token(sdk.NewInt(102), myTokenContractAddr.GetAddress().Hex())
 	expUnbatchedTx = []*types.InternalOutgoingTransferTx{
 		{
 			Id:          2,
@@ -382,7 +382,7 @@ func TestBatchesFullCoins(t *testing.T) {
 	assert.Equal(t, expFirstBatch.BatchTimeout, gotFirstBatch.BatchTimeout)
 	assert.Equal(t, expFirstBatch.BatchNonce, gotFirstBatch.BatchNonce)
 	assert.Equal(t, expFirstBatch.Block, gotFirstBatch.Block)
-	assert.Equal(t, expFirstBatch.TokenContract, gotFirstBatch.TokenContract.GetAddress())
+	assert.Equal(t, expFirstBatch.TokenContract, gotFirstBatch.TokenContract.GetAddress().Hex())
 	assert.Equal(t, len(expFirstBatch.Transactions), len(gotFirstBatch.Transactions))
 	for i := 0; i < len(expFirstBatch.Transactions); i++ {
 		assert.Equal(t, expFirstBatch.Transactions[i], gotFirstBatch.Transactions[i].ToExternal())
@@ -459,7 +459,7 @@ func TestBatchesFullCoins(t *testing.T) {
 	assert.Equal(t, expSecondBatch.BatchTimeout, secondBatch.BatchTimeout)
 	assert.Equal(t, expSecondBatch.BatchNonce, secondBatch.BatchNonce)
 	assert.Equal(t, expSecondBatch.Block, secondBatch.Block)
-	assert.Equal(t, expSecondBatch.TokenContract, secondBatch.TokenContract.GetAddress())
+	assert.Equal(t, expSecondBatch.TokenContract, secondBatch.TokenContract.GetAddress().Hex())
 	assert.Equal(t, len(expSecondBatch.Transactions), len(secondBatch.Transactions))
 	for i := 0; i < len(expSecondBatch.Transactions); i++ {
 		assert.Equal(t, expSecondBatch.Transactions[i], secondBatch.Transactions[i].ToExternal())
@@ -706,7 +706,7 @@ func TestBatchesNotCreatedWhenBridgePaused(t *testing.T) {
 		mySender, _            = sdk.AccAddressFromBech32("gravity1ahx7f8wyertuus9r20284ej0asrs085ceqtfnm")
 		myReceiver, _          = types.NewEthAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr, _ = types.NewEthAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
-		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress())
+		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress().Hex())
 		allVouchers            = sdk.NewCoins(token.GravityCoin())
 	)
 	require.NoError(t, err)
@@ -722,10 +722,10 @@ func TestBatchesNotCreatedWhenBridgePaused(t *testing.T) {
 
 	// add some TX to the pool
 	for i, v := range []uint64{2, 3, 2, 1} {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress())
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
@@ -779,14 +779,14 @@ func TestEthereumBlacklistBatches(t *testing.T) {
 		myReceiver, _          = types.NewEthAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		blacklistedReceiver, _ = types.NewEthAddress("0x4d16b9E4a27c3313440923fEfCd013178149A5bD")
 		myTokenContractAddr, _ = types.NewEthAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
-		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress())
+		token, err             = types.NewInternalERC20Token(sdk.NewInt(99999), myTokenContractAddr.GetAddress().Hex())
 		allVouchers            = sdk.NewCoins(token.GravityCoin())
 	)
 	require.NoError(t, err)
 
 	// add the blacklisted address to the blacklist
 	params := input.GravityKeeper.GetParams(ctx)
-	params.EthereumBlacklist = append(params.EthereumBlacklist, blacklistedReceiver.GetAddress())
+	params.EthereumBlacklist = append(params.EthereumBlacklist, blacklistedReceiver.GetAddress().Hex())
 	input.GravityKeeper.SetParams(ctx, params)
 
 	// mint some voucher first
@@ -800,10 +800,10 @@ func TestEthereumBlacklistBatches(t *testing.T) {
 
 	// add some TX to the pool
 	for i, v := range []uint64{2, 3, 2, 1, 5} {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress())
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
@@ -899,7 +899,7 @@ func TestBatchConfirms(t *testing.T) {
 		mySender, _            = sdk.AccAddressFromBech32("gravity1ahx7f8wyertuus9r20284ej0asrs085ceqtfnm")
 		myReceiver, _          = types.NewEthAddress("0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7")
 		myTokenContractAddr, _ = types.NewEthAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5") // Pickle
-		token, err             = types.NewInternalERC20Token(sdk.NewInt(1000000), myTokenContractAddr.GetAddress())
+		token, err             = types.NewInternalERC20Token(sdk.NewInt(1000000), myTokenContractAddr.GetAddress().Hex())
 		allVouchers            = sdk.NewCoins(token.GravityCoin())
 	)
 	require.NoError(t, err)
@@ -915,10 +915,10 @@ func TestBatchConfirms(t *testing.T) {
 
 	// add batches with 1 tx to the pool
 	for i := 1; i < 200; i++ {
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress())
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		amount := amountToken.GravityCoin()
-		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(uint64(i+10)), myTokenContractAddr.GetAddress())
+		feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(uint64(i+10)), myTokenContractAddr.GetAddress().Hex())
 		require.NoError(t, err)
 		fee := feeToken.GravityCoin()
 
@@ -942,8 +942,8 @@ func TestBatchConfirms(t *testing.T) {
 
 			conf := &types.MsgConfirmBatch{
 				Nonce:         batch.BatchNonce,
-				TokenContract: batch.TokenContract.GetAddress(),
-				EthSigner:     ethAddr.GetAddress(),
+				TokenContract: batch.TokenContract.GetAddress().Hex(),
+				EthSigner:     ethAddr.GetAddress().Hex(),
 				Orchestrator:  orch.String(),
 				Signature:     "dummysig",
 			}
@@ -955,7 +955,7 @@ func TestBatchConfirms(t *testing.T) {
 	//try to set connfirm with invalid address
 	conf := &types.MsgConfirmBatch{
 		Nonce:         outogoingBatches[0].BatchNonce,
-		TokenContract: outogoingBatches[0].TokenContract.GetAddress(),
+		TokenContract: outogoingBatches[0].TokenContract.GetAddress().Hex(),
 		EthSigner:     EthAddrs[0].String(),
 		Orchestrator:  "invalid address",
 		Signature:     "dummysig",
@@ -978,7 +978,7 @@ func TestBatchConfirms(t *testing.T) {
 		for i, addr := range OrchAddrs {
 			batchConfirm = input.GravityKeeper.GetBatchConfirm(ctx, batch.BatchNonce, batch.TokenContract, addr)
 			require.Equal(t, batch.BatchNonce, batchConfirm.Nonce)
-			require.Equal(t, batch.TokenContract.GetAddress(), batchConfirm.TokenContract)
+			require.Equal(t, batch.TokenContract.GetAddress().Hex(), batchConfirm.TokenContract)
 			require.Equal(t, EthAddrs[i].String(), batchConfirm.EthSigner)
 			require.Equal(t, addr.String(), batchConfirm.Orchestrator)
 			require.Equal(t, "dummysig", batchConfirm.Signature)

--- a/module/x/gravity/keeper/cosmos-originated.go
+++ b/module/x/gravity/keeper/cosmos-originated.go
@@ -24,7 +24,7 @@ func (k Keeper) GetCosmosOriginatedERC20(ctx sdk.Context, denom string) (*types.
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get([]byte(types.GetDenomToERC20Key(denom)))
 	if bz != nil {
-		ethAddr, err := types.NewEthAddress(string(bz))
+		ethAddr, err := types.NewEthAddressFromBytes(bz)
 		if err != nil {
 			panic(fmt.Errorf("discovered invalid ERC20 address under key %v", string(bz)))
 		}
@@ -36,7 +36,7 @@ func (k Keeper) GetCosmosOriginatedERC20(ctx sdk.Context, denom string) (*types.
 
 func (k Keeper) setCosmosOriginatedDenomToERC20(ctx sdk.Context, denom string, tokenContract types.EthAddress) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set([]byte(types.GetDenomToERC20Key(denom)), []byte(tokenContract.GetAddress()))
+	store.Set([]byte(types.GetDenomToERC20Key(denom)), tokenContract.GetAddress().Bytes())
 	store.Set([]byte(types.GetERC20ToDenomKey(tokenContract)), []byte(denom))
 }
 

--- a/module/x/gravity/keeper/evidence.go
+++ b/module/x/gravity/keeper/evidence.go
@@ -66,7 +66,7 @@ func (k Keeper) checkBadSignatureEvidenceInternal(ctx sdk.Context, subject types
 	// Find the offending validator by eth address
 	val, found := k.GetValidatorByEthAddress(ctx, *ethAddress)
 	if !found {
-		return sdkerrors.Wrap(types.ErrInvalid, fmt.Sprintf("Did not find validator for eth address %s from signature %s with checkpoint %s and GravityID %s", ethAddress, signature, hex.EncodeToString(checkpoint), gravityID))
+		return sdkerrors.Wrap(types.ErrInvalid, fmt.Sprintf("Did not find validator for eth address %s from signature %s with checkpoint %s and GravityID %s", ethAddress.GetAddress().Hex(), signature, hex.EncodeToString(checkpoint), gravityID))
 	}
 
 	// Slash the offending validator

--- a/module/x/gravity/keeper/genesis_test.go
+++ b/module/x/gravity/keeper/genesis_test.go
@@ -39,8 +39,8 @@ func TestBatchAndTxImportExport(t *testing.T) {
 	}
 	ctrAddresses := []string{ // Warning: this must match the length of accAddresses
 		"0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5",
-		"0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6",
-		"0x429881672B9AE42b8EbA0E26cD9C73711b891Ca7",
+		"0x429881672b9AE42b8eBA0e26cd9c73711b891ca6",
+		"0x429881672b9aE42b8eba0e26cD9c73711B891Ca7",
 		"0x429881672B9AE42b8EbA0E26cD9C73711b891Ca8",
 		"0x429881672B9AE42b8EbA0E26cD9C73711b891Ca9",
 	}
@@ -68,7 +68,7 @@ func TestBatchAndTxImportExport(t *testing.T) {
 	tokens := make([]*types.InternalERC20Token, len(contracts))
 	vouchers := make([]*sdk.Coins, len(contracts))
 	for i, v := range contracts {
-		token, err := types.NewInternalERC20Token(sdk.NewInt(99999999), v.GetAddress())
+		token, err := types.NewInternalERC20Token(sdk.NewInt(99999999), v.GetAddress().Hex())
 		tokens[i] = token
 		allVouchers := sdk.NewCoins(token.GravityCoin())
 		vouchers[i] = &allVouchers
@@ -99,9 +99,9 @@ func TestBatchAndTxImportExport(t *testing.T) {
 		sender := senders[i%len(senders)]
 		receiver := receivers[i%len(receivers)]
 		contract := contracts[i%len(contracts)]
-		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(amount)), contract.GetAddress())
+		amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(amount)), contract.GetAddress().Hex())
 		require.NoError(t, err)
-		feeToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(fee)), contract.GetAddress())
+		feeToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(fee)), contract.GetAddress().Hex())
 		require.NoError(t, err)
 
 		// add transaction to the pool
@@ -110,7 +110,7 @@ func TestBatchAndTxImportExport(t *testing.T) {
 		ctx.Logger().Info(fmt.Sprintf("Created transaction %v with amount %v and fee %v of contract %v from %v to %v", i, amount, fee, contract, sender, receiver))
 
 		// Record the transaction for later testing
-		tx, err := types.NewInternalOutgoingTransferTx(id, sender.String(), receiver.GetAddress(), amountToken.ToExternal(), feeToken.ToExternal())
+		tx, err := types.NewInternalOutgoingTransferTx(id, sender.String(), receiver.GetAddress().Hex(), amountToken.ToExternal(), feeToken.ToExternal())
 		require.NoError(t, err)
 		txs[i] = tx
 	}

--- a/module/x/gravity/keeper/grpc_query.go
+++ b/module/x/gravity/keeper/grpc_query.go
@@ -284,7 +284,7 @@ func (k Keeper) DenomToERC20(
 	ctx := sdk.UnwrapSDKContext(c)
 	cosmosOriginated, erc20, err := k.DenomToERC20Lookup(ctx, req.Denom)
 	var ret types.QueryDenomToERC20Response
-	ret.Erc20 = erc20.GetAddress()
+	ret.Erc20 = erc20.GetAddress().Hex()
 	ret.CosmosOriginated = cosmosOriginated
 
 	return &ret, err

--- a/module/x/gravity/keeper/invariants_test.go
+++ b/module/x/gravity/keeper/invariants_test.go
@@ -85,10 +85,10 @@ func TestModuleBalanceBatchedTxs(t *testing.T) {
 		myTokenContractAddr2, _ = types.NewEthAddress("0xF815240800ddf3E0be80e0d848B13ecaa504BF37")
 	)
 	tokens := make([]*types.InternalERC20Token, 2)
-	tokens[0], _ = types.NewInternalERC20Token(sdk.NewInt(150000000000000), myTokenContractAddr1.GetAddress())
-	tokens[1], _ = types.NewInternalERC20Token(sdk.NewInt(150000000000000), myTokenContractAddr2.GetAddress())
-	voucher1, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr1.GetAddress())
-	voucher2, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr2.GetAddress())
+	tokens[0], _ = types.NewInternalERC20Token(sdk.NewInt(150000000000000), myTokenContractAddr1.GetAddress().Hex())
+	tokens[1], _ = types.NewInternalERC20Token(sdk.NewInt(150000000000000), myTokenContractAddr2.GetAddress().Hex())
+	voucher1, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr1.GetAddress().Hex())
+	voucher2, _ := types.NewInternalERC20Token(sdk.NewInt(1), myTokenContractAddr2.GetAddress().Hex())
 	voucherCoins := []sdk.Coins{
 		sdk.NewCoins(voucher1.GravityCoin()),
 		sdk.NewCoins(voucher2.GravityCoin()),
@@ -113,10 +113,10 @@ func TestModuleBalanceBatchedTxs(t *testing.T) {
 	for _, tok := range tokens {
 		// add some TX to the pool
 		for i, v := range []uint64{2, 3, 2, 1, 2, 4, 5, 1} {
-			amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), tok.Contract.GetAddress())
+			amountToken, err := types.NewInternalERC20Token(sdk.NewInt(int64(i+100)), tok.Contract.GetAddress().Hex())
 			require.NoError(t, err)
 			amount := amountToken.GravityCoin()
-			feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), tok.Contract.GetAddress())
+			feeToken, err := types.NewInternalERC20Token(sdk.NewIntFromUint64(v), tok.Contract.GetAddress().Hex())
 			require.NoError(t, err)
 			fee := feeToken.GravityCoin()
 

--- a/module/x/gravity/keeper/keeper.go
+++ b/module/x/gravity/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -198,7 +199,7 @@ func (k Keeper) GetDelegateKeys(ctx sdk.Context) []types.MsgSetOrchestratorAddre
 	iter := store.Iterator(prefixRange(prefix))
 	defer iter.Close()
 
-	ethAddresses := make(map[string]string)
+	ethAddresses := make(map[string]gethcommon.Address)
 
 	for ; iter.Valid(); iter.Next() {
 		// the 'key' contains both the prefix and the value, so we need
@@ -207,7 +208,7 @@ func (k Keeper) GetDelegateKeys(ctx sdk.Context) []types.MsgSetOrchestratorAddre
 		// of the actual key
 		key := iter.Key()[len(types.GetEthAddressByValidatorPrefix()):]
 		value := iter.Value()
-		ethAddress, err := types.NewEthAddress(string(value))
+		ethAddress, err := types.NewEthAddressFromBytes(value)
 		if err != nil {
 			panic(sdkerrors.Wrapf(err, "found invalid ethAddress %v under key %v", string(value), key))
 		}
@@ -252,7 +253,7 @@ func (k Keeper) GetDelegateKeys(ctx sdk.Context) []types.MsgSetOrchestratorAddre
 		result = append(result, types.MsgSetOrchestratorAddress{
 			Orchestrator: orch,
 			Validator:    valAddr,
-			EthAddress:   ethAddr,
+			EthAddress:   ethAddr.Hex(),
 		})
 
 	}

--- a/module/x/gravity/keeper/keeper_batch.go
+++ b/module/x/gravity/keeper/keeper_batch.go
@@ -24,7 +24,7 @@ func (k Keeper) GetBatchConfirm(ctx sdk.Context, nonce uint64, tokenContract typ
 	}
 	confirm := types.MsgConfirmBatch{
 		Nonce:         nonce,
-		TokenContract: tokenContract.GetAddress(),
+		TokenContract: tokenContract.GetAddress().Hex(),
 		EthSigner:     "",
 		Orchestrator:  "",
 		Signature:     "",
@@ -76,7 +76,7 @@ func (k Keeper) IterateBatchConfirmByNonceAndTokenContract(ctx sdk.Context, nonc
 	for ; iter.Valid(); iter.Next() {
 		confirm := types.MsgConfirmBatch{
 			Nonce:         nonce,
-			TokenContract: tokenContract.GetAddress(),
+			TokenContract: tokenContract.GetAddress().Hex(),
 			EthSigner:     "",
 			Orchestrator:  "",
 			Signature:     "",

--- a/module/x/gravity/keeper/keeper_delegate_key.go
+++ b/module/x/gravity/keeper/keeper_delegate_key.go
@@ -152,7 +152,6 @@ func (k Keeper) GetEthAddressByValidator(ctx sdk.Context, validator sdk.ValAddre
 		return nil, false
 	}
 
-	// TODO: Migrate this!
 	addr, err := types.NewEthAddressFromBytes(ethAddr)
 	if err != nil {
 		return nil, false

--- a/module/x/gravity/keeper/keeper_delegate_key.go
+++ b/module/x/gravity/keeper/keeper_delegate_key.go
@@ -136,7 +136,8 @@ func (k Keeper) SetEthAddressForValidator(ctx sdk.Context, validator sdk.ValAddr
 		panic(sdkerrors.Wrap(err, "invalid validator address"))
 	}
 	store := ctx.KVStore(k.storeKey)
-	store.Set([]byte(types.GetEthAddressByValidatorKey(validator)), []byte(ethAddr.GetAddress()))
+
+	store.Set([]byte(types.GetEthAddressByValidatorKey(validator)), ethAddr.GetAddress().Bytes())
 	store.Set([]byte(types.GetValidatorByEthAddressKey(ethAddr)), []byte(validator))
 }
 
@@ -151,7 +152,8 @@ func (k Keeper) GetEthAddressByValidator(ctx sdk.Context, validator sdk.ValAddre
 		return nil, false
 	}
 
-	addr, err := types.NewEthAddress(string(ethAddr))
+	// TODO: Migrate this!
+	addr, err := types.NewEthAddressFromBytes(ethAddr)
 	if err != nil {
 		return nil, false
 	}

--- a/module/x/gravity/keeper/keeper_valset.go
+++ b/module/x/gravity/keeper/keeper_valset.go
@@ -41,7 +41,7 @@ func (k Keeper) SetValsetRequest(ctx sdk.Context) types.Valset {
 
 	ctx.EventManager().EmitTypedEvent(
 		&types.EventMultisigUpdateRequest{
-			BridgeContract: k.GetBridgeContractAddress(ctx).GetAddress(),
+			BridgeContract: k.GetBridgeContractAddress(ctx).GetAddress().Hex(),
 			BridgeChainId:  strconv.Itoa(int(k.GetBridgeChainID(ctx))),
 			MultisigId:     fmt.Sprint(valset.Nonce),
 			Nonce:          fmt.Sprint(valset.Nonce),
@@ -272,7 +272,7 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 		p := sdk.NewInt(k.StakingKeeper.GetLastValidatorPower(ctx, val))
 
 		if ethAddr, found := k.GetEthAddressByValidator(ctx, val); found {
-			bv := types.BridgeValidator{Power: p.Uint64(), EthereumAddress: ethAddr.GetAddress()}
+			bv := types.BridgeValidator{Power: p.Uint64(), EthereumAddress: ethAddr.GetAddress().Hex()}
 			ibv, err := types.NewInternalBridgeValidator(bv)
 			if err != nil {
 				return types.Valset{}, sdkerrors.Wrapf(err, types.ErrInvalidEthAddress.Error(), val)

--- a/module/x/gravity/keeper/migrations.go
+++ b/module/x/gravity/keeper/migrations.go
@@ -1,0 +1,21 @@
+package keeper
+
+import (
+	v2 "github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/migrations/v2"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Migrator is a struct for handling in-place store migrations.
+type Migrator struct {
+	keeper Keeper
+}
+
+// NewMigrator returns a new Migrator.
+func NewMigrator(keeper Keeper) Migrator {
+	return Migrator{keeper: keeper}
+}
+
+// Migrate1to2 migrates from consensus version 1 to 2.
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v2.MigrateStore(ctx, m.keeper.storeKey, m.keeper.cdc)
+}

--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -54,7 +54,7 @@ func (k msgServer) SetOrchestratorAddress(c context.Context, msg *types.MsgSetOr
 	// check that neither key is a duplicate
 	delegateKeys := k.GetDelegateKeys(ctx)
 	for i := range delegateKeys {
-		if delegateKeys[i].EthAddress == addr.GetAddress() {
+		if delegateKeys[i].EthAddress == addr.GetAddress().Hex() {
 			return nil, sdkerrors.Wrap(err, "Duplicate Ethereum Key")
 		}
 		if delegateKeys[i].Orchestrator == orch.String() {

--- a/module/x/gravity/keeper/msg_server_test.go
+++ b/module/x/gravity/keeper/msg_server_test.go
@@ -1,0 +1,136 @@
+package keeper
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfirmHandlerCommon(t *testing.T) {
+	input, ctx := SetupFiveValChain(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	ethAddress, err := types.NewEthAddress(crypto.PubkeyToAddress(privKey.PublicKey).String())
+	require.NoError(t, err)
+
+	input.GravityKeeper.SetEthAddressForValidator(ctx, ValAddrs[0], *ethAddress)
+	input.GravityKeeper.SetOrchestratorValidator(ctx, ValAddrs[0], AccAddrs[0])
+
+	batch := types.OutgoingTxBatch{
+		TokenContract: "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7",
+		BatchTimeout:  420,
+	}
+
+	checkpoint := batch.GetCheckpoint(input.GravityKeeper.GetGravityID(ctx))
+
+	ethSignature, err := types.NewEthereumSignature(checkpoint, privKey)
+	require.NoError(t, err)
+
+	sv := msgServer{input.GravityKeeper}
+	err = sv.confirmHandlerCommon(input.Context, ethAddress.GetAddress().Hex(), AccAddrs[0], hex.EncodeToString(ethSignature), checkpoint)
+	assert.Nil(t, err)
+}
+
+func TestConfirmHandlerCommonWithLowercaseAddress(t *testing.T) {
+	input, ctx := SetupFiveValChain(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	ethAddress, err := types.NewEthAddress(crypto.PubkeyToAddress(privKey.PublicKey).String())
+	require.NoError(t, err)
+
+	input.GravityKeeper.SetEthAddressForValidator(ctx, ValAddrs[0], *ethAddress)
+	input.GravityKeeper.SetOrchestratorValidator(ctx, ValAddrs[0], AccAddrs[0])
+
+	batch := types.OutgoingTxBatch{
+		TokenContract: "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7",
+		BatchTimeout:  420,
+	}
+
+	checkpoint := batch.GetCheckpoint(input.GravityKeeper.GetGravityID(ctx))
+
+	ethSignature, err := types.NewEthereumSignature(checkpoint, privKey)
+	require.NoError(t, err)
+
+	sv := msgServer{input.GravityKeeper}
+	err = sv.confirmHandlerCommon(input.Context, strings.ToLower(ethAddress.GetAddress().Hex()), AccAddrs[0], hex.EncodeToString(ethSignature), checkpoint)
+	assert.Nil(t, err)
+}
+
+func TestConfirmHandlerCommonWithUppercaseAddress(t *testing.T) {
+	input, ctx := SetupFiveValChain(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	ethAddress, err := types.NewEthAddress(crypto.PubkeyToAddress(privKey.PublicKey).String())
+	require.NoError(t, err)
+
+	input.GravityKeeper.SetEthAddressForValidator(ctx, ValAddrs[0], *ethAddress)
+	input.GravityKeeper.SetOrchestratorValidator(ctx, ValAddrs[0], AccAddrs[0])
+
+	batch := types.OutgoingTxBatch{
+		TokenContract: "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7",
+		BatchTimeout:  420,
+	}
+
+	checkpoint := batch.GetCheckpoint(input.GravityKeeper.GetGravityID(ctx))
+
+	ethSignature, err := types.NewEthereumSignature(checkpoint, privKey)
+	require.NoError(t, err)
+
+	sv := msgServer{input.GravityKeeper}
+	err = sv.confirmHandlerCommon(input.Context, strings.ToUpper(ethAddress.GetAddress().Hex()), AccAddrs[0], hex.EncodeToString(ethSignature), checkpoint)
+	assert.Nil(t, err)
+}
+
+func TestConfirmHandlerCommonWithMixedCaseAddress(t *testing.T) {
+	input, ctx := SetupFiveValChain(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	ethAddress, err := types.NewEthAddress(crypto.PubkeyToAddress(privKey.PublicKey).String())
+	require.NoError(t, err)
+
+	input.GravityKeeper.SetEthAddressForValidator(ctx, ValAddrs[0], *ethAddress)
+	input.GravityKeeper.SetOrchestratorValidator(ctx, ValAddrs[0], AccAddrs[0])
+
+	batch := types.OutgoingTxBatch{
+		TokenContract: "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7",
+		BatchTimeout:  420,
+	}
+
+	checkpoint := batch.GetCheckpoint(input.GravityKeeper.GetGravityID(ctx))
+
+	ethSignature, err := types.NewEthereumSignature(checkpoint, privKey)
+	require.NoError(t, err)
+
+	sv := msgServer{input.GravityKeeper}
+
+	mixedCase := []rune(ethAddress.GetAddress().Hex())
+	for i := range mixedCase {
+		if rand.Float64() > 0.5 {
+			mixedCase[i] = unicode.ToLower(mixedCase[i])
+		} else {
+			mixedCase[i] = unicode.ToUpper(mixedCase[i])
+		}
+	}
+
+	err = sv.confirmHandlerCommon(input.Context, string(mixedCase), AccAddrs[0], hex.EncodeToString(ethSignature), checkpoint)
+	assert.Nil(t, err)
+}

--- a/module/x/gravity/keeper/pool_test.go
+++ b/module/x/gravity/keeper/pool_test.go
@@ -174,7 +174,7 @@ func TestAddToOutgoingPoolEdgeCases(t *testing.T) {
 	require.Zero(t, r)
 
 	//////// Inconsistent Entry ////////
-	badFeeContractAddr := "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6"
+	badFeeContractAddr := "0x429881672b9AE42b8eBA0e26cd9c73711b891ca6"
 	badFeeToken, err = types.NewInternalERC20Token(sdk.NewInt(100), badFeeContractAddr)
 	require.NoError(t, err)
 	badFee = badFeeToken.GravityCoin()
@@ -280,8 +280,8 @@ func TestGetBatchFeeByTokenType(t *testing.T) {
 		mySender3            sdk.AccAddress = []byte("gravity1ahx7f8wyertut")
 		myReceiver                          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
 		myTokenContractAddr1                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5"
-		myTokenContractAddr2                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6"
-		myTokenContractAddr3                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca7"
+		myTokenContractAddr2                = "0x429881672b9AE42b8eBA0e26cd9c73711b891ca6"
+		myTokenContractAddr3                = "0x429881672b9aE42b8eba0e26cD9c73711B891Ca7"
 	)
 	receiver, err := types.NewEthAddress(myReceiver)
 	require.NoError(t, err)
@@ -487,10 +487,10 @@ func TestRefundInconsistentTx(t *testing.T) {
 	)
 
 	//////// Refund an inconsistent tx ////////
-	amountToken, err := types.NewInternalERC20Token(sdk.NewInt(100), myTokenContractAddr.GetAddress())
+	amountToken, err := types.NewInternalERC20Token(sdk.NewInt(100), myTokenContractAddr.GetAddress().Hex())
 	require.NoError(t, err)
-	badTokenContractAddr, _ := types.NewEthAddress("0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6") // different last char
-	badFeeToken, err := types.NewInternalERC20Token(sdk.NewInt(2), badTokenContractAddr.GetAddress())
+	badTokenContractAddr, _ := types.NewEthAddress("0x429881672b9AE42b8eBA0e26cd9c73711b891ca6") // different last char
+	badFeeToken, err := types.NewInternalERC20Token(sdk.NewInt(2), badTokenContractAddr.GetAddress().Hex())
 	require.NoError(t, err)
 
 	// This way should fail
@@ -596,7 +596,7 @@ func TestGetUnbatchedTransactions(t *testing.T) {
 		mySender2            sdk.AccAddress = []byte("gravity1ahx7f8wyertus")
 		myReceiver                          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
 		myTokenContractAddr1                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5"
-		myTokenContractAddr2                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6"
+		myTokenContractAddr2                = "0x429881672b9AE42b8eBA0e26cd9c73711b891ca6"
 	)
 	receiver, err := types.NewEthAddress(myReceiver)
 	require.NoError(t, err)
@@ -705,18 +705,18 @@ func TestGetUnbatchedTransactions(t *testing.T) {
 	for _, v := range token1Txs {
 		expTx := idToTxMap[v.Id]
 		require.NotNil(t, expTx)
-		require.Equal(t, myTokenContractAddr1, v.Erc20Fee.Contract.GetAddress())
-		require.Equal(t, myTokenContractAddr1, v.Erc20Token.Contract.GetAddress())
-		require.Equal(t, expTx.DestAddress, v.DestAddress.GetAddress())
+		require.Equal(t, myTokenContractAddr1, v.Erc20Fee.Contract.GetAddress().Hex())
+		require.Equal(t, myTokenContractAddr1, v.Erc20Token.Contract.GetAddress().Hex())
+		require.Equal(t, expTx.DestAddress, v.DestAddress.GetAddress().Hex())
 		require.Equal(t, expTx.Sender, v.Sender.String())
 	}
 	token2Txs := input.GravityKeeper.GetUnbatchedTransactionsByContract(ctx, *tokenContract2)
 	for _, v := range token2Txs {
 		expTx := idToTxMap[v.Id]
 		require.NotNil(t, expTx)
-		require.Equal(t, myTokenContractAddr2, v.Erc20Fee.Contract.GetAddress())
-		require.Equal(t, myTokenContractAddr2, v.Erc20Token.Contract.GetAddress())
-		require.Equal(t, expTx.DestAddress, v.DestAddress.GetAddress())
+		require.Equal(t, myTokenContractAddr2, v.Erc20Fee.Contract.GetAddress().Hex())
+		require.Equal(t, myTokenContractAddr2, v.Erc20Token.Contract.GetAddress().Hex())
+		require.Equal(t, expTx.DestAddress, v.DestAddress.GetAddress().Hex())
 		require.Equal(t, expTx.Sender, v.Sender.String())
 	}
 	// GetUnbatchedTransactions
@@ -724,10 +724,10 @@ func TestGetUnbatchedTransactions(t *testing.T) {
 	for _, v := range allTxs {
 		expTx := idToTxMap[v.Id]
 		require.NotNil(t, expTx)
-		require.Equal(t, expTx.DestAddress, v.DestAddress.GetAddress())
+		require.Equal(t, expTx.DestAddress, v.DestAddress.GetAddress().Hex())
 		require.Equal(t, expTx.Sender, v.Sender.String())
-		require.Equal(t, expTx.Erc20Fee.Contract, v.Erc20Fee.Contract.GetAddress())
-		require.Equal(t, expTx.Erc20Token.Contract, v.Erc20Token.Contract.GetAddress())
+		require.Equal(t, expTx.Erc20Fee.Contract, v.Erc20Fee.Contract.GetAddress().Hex())
+		require.Equal(t, expTx.Erc20Token.Contract, v.Erc20Token.Contract.GetAddress().Hex())
 	}
 }
 
@@ -744,7 +744,7 @@ func TestIterateUnbatchedTransactions(t *testing.T) {
 		mySender2            sdk.AccAddress = []byte("gravity1ahx7f8wyertus")
 		myReceiver                          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
 		myTokenContractAddr1                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5"
-		myTokenContractAddr2                = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca6"
+		myTokenContractAddr2                = "0x429881672b9AE42b8eBA0e26cd9c73711b891ca6"
 	)
 	receiver, err := types.NewEthAddress(myReceiver)
 	require.NoError(t, err)
@@ -843,7 +843,7 @@ func TestIterateUnbatchedTransactions(t *testing.T) {
 		require.NotNil(t, tx)
 		fTx := idToTxMap[tx.Id]
 		require.NotNil(t, fTx)
-		require.Equal(t, fTx.DestAddress, tx.DestAddress.GetAddress())
+		require.Equal(t, fTx.DestAddress, tx.DestAddress.GetAddress().Hex())
 
 		anotherFoundMap[fTx.Id] = true
 		return false

--- a/module/x/gravity/keeper/querier_test.go
+++ b/module/x/gravity/keeper/querier_test.go
@@ -35,7 +35,7 @@ func TestQueryValsetConfirm(t *testing.T) {
 	input.GravityKeeper.SetValsetConfirm(sdkCtx, types.MsgValsetConfirm{
 		Nonce:        nonce,
 		Orchestrator: myValidatorCosmosAddr.String(),
-		EthAddress:   myValidatorEthereumAddr.GetAddress(),
+		EthAddress:   myValidatorEthereumAddr.GetAddress().Hex(),
 		Signature:    "alksdjhflkasjdfoiasjdfiasjdfoiasdj",
 	})
 
@@ -987,7 +987,7 @@ func TestQueryERC20ToDenom(t *testing.T) {
 	k := input.GravityKeeper
 	input.GravityKeeper.setCosmosOriginatedDenomToERC20(sdkCtx, denom, *erc20)
 
-	queriedDenom, err := k.ERC20ToDenom(ctx, &types.QueryERC20ToDenomRequest{Erc20: erc20.GetAddress()})
+	queriedDenom, err := k.ERC20ToDenom(ctx, &types.QueryERC20ToDenomRequest{Erc20: erc20.GetAddress().Hex()})
 	require.NoError(t, err)
 
 	assert.Equal(t, &response, queriedDenom)
@@ -1001,7 +1001,7 @@ func TestQueryDenomToERC20(t *testing.T) {
 	)
 	require.NoError(t, err)
 	response := types.QueryDenomToERC20Response{
-		Erc20:            erc20.GetAddress(),
+		Erc20:            erc20.GetAddress().Hex(),
 		CosmosOriginated: true,
 	}
 	input := CreateTestEnv(t)

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -229,16 +229,17 @@ var (
 
 // TestInput stores the various keepers required to test gravity
 type TestInput struct {
-	GravityKeeper  Keeper
-	AccountKeeper  authkeeper.AccountKeeper
-	StakingKeeper  stakingkeeper.Keeper
-	SlashingKeeper slashingkeeper.Keeper
-	DistKeeper     distrkeeper.Keeper
-	BankKeeper     bankkeeper.BaseKeeper
-	GovKeeper      govkeeper.Keeper
-	Context        sdk.Context
-	Marshaler      codec.Codec
-	LegacyAmino    *codec.LegacyAmino
+	GravityKeeper   Keeper
+	AccountKeeper   authkeeper.AccountKeeper
+	StakingKeeper   stakingkeeper.Keeper
+	SlashingKeeper  slashingkeeper.Keeper
+	DistKeeper      distrkeeper.Keeper
+	BankKeeper      bankkeeper.BaseKeeper
+	GovKeeper       govkeeper.Keeper
+	Context         sdk.Context
+	Marshaler       codec.Codec
+	LegacyAmino     *codec.LegacyAmino
+	GravityStoreKey *sdk.KVStoreKey
 }
 
 // SetupFiveValChain does all the initialization for a 5 Validator chain using the keys here
@@ -565,16 +566,17 @@ func CreateTestEnv(t *testing.T) TestInput {
 	fmt.Println(params)
 
 	testInput := TestInput{
-		GravityKeeper:  k,
-		AccountKeeper:  accountKeeper,
-		BankKeeper:     bankKeeper,
-		StakingKeeper:  stakingKeeper,
-		SlashingKeeper: slashingKeeper,
-		DistKeeper:     distKeeper,
-		GovKeeper:      govKeeper,
-		Context:        ctx,
-		Marshaler:      marshaler,
-		LegacyAmino:    cdc,
+		GravityKeeper:   k,
+		AccountKeeper:   accountKeeper,
+		BankKeeper:      bankKeeper,
+		StakingKeeper:   stakingKeeper,
+		SlashingKeeper:  slashingKeeper,
+		DistKeeper:      distKeeper,
+		GovKeeper:       govKeeper,
+		Context:         ctx,
+		Marshaler:       marshaler,
+		LegacyAmino:     cdc,
+		GravityStoreKey: gravityKey,
 	}
 	// check invariants before starting
 	testInput.Context.Logger().Info("Asserting invariants on new test env")

--- a/module/x/gravity/migrations/v2/keys.go
+++ b/module/x/gravity/migrations/v2/keys.go
@@ -1,0 +1,16 @@
+package v2
+
+// Store prefixes
+const (
+	StoreKey = "gravity"
+
+	DenomToERC20Key = "DenomToERC20Key"
+	ERC20ToDenomKey = "ERC20ToDenomKey"
+
+	EthAddressByValidatorKey = "EthAddressValidatorKey"
+	ValidatorByEthAddressKey = "ValidatorByEthAddressKey"
+
+	BatchConfirmKey    = "BatchConfirmKey"
+	OutgoingTXPoolKey  = "OutgoingTXPoolKey"
+	OutgoingTXBatchKey = "OutgoingTXBatchKey"
+)

--- a/module/x/gravity/migrations/v2/store.go
+++ b/module/x/gravity/migrations/v2/store.go
@@ -1,0 +1,178 @@
+package v2
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ethcmn "github.com/ethereum/go-ethereum/common"
+)
+
+// MigrateStore performs in-place store migrations from v1 to v2. The migration
+// includes:
+//
+// - Change all Cosmos orginated ERC20 mappings from (HEX) string to bytes.
+// - Change all validator Ethereum keys from (HEX) string to bytes.
+func MigrateStore(ctx sdk.Context, storeKey storetypes.StoreKey, cdc codec.BinaryCodec) error {
+	store := ctx.KVStore(storeKey)
+
+	// Denoms
+	if err := migrateCosmosOriginatedDenomToERC20(store); err != nil {
+		return err
+	}
+
+	if err := migrateCosmosOriginatedERC20ToDenom(store); err != nil {
+		return err
+	}
+
+	// Validators' Ethereum addresses
+	if err := migrateEthAddressByValidator(store); err != nil {
+		return err
+	}
+
+	if err := migrateValidatorByEthAddressKey(store); err != nil {
+		return err
+	}
+
+	// Batch confirmations
+	if err := migrateBatchConfirms(store); err != nil {
+		return err
+	}
+
+	if err := migrateOutgoingTxs(store); err != nil {
+		return err
+	}
+
+	if err := migrateOutgoingTxBatches(store); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func migrateCosmosOriginatedDenomToERC20(store storetypes.KVStore) error {
+	prefixStore := prefix.NewStore(store, []byte(DenomToERC20Key))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		addrStr := string(iterator.Value())
+		addr := ethcmn.HexToAddress(addrStr)
+
+		prefixStore.Set(iterator.Key(), addr.Bytes())
+	}
+
+	return nil
+}
+
+func migrateCosmosOriginatedERC20ToDenom(store storetypes.KVStore) error {
+	prefixStore := prefix.NewStore(store, []byte(ERC20ToDenomKey))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		oldKey := iterator.Key()
+
+		newKey := string(ethcmn.HexToAddress(string(oldKey)).Bytes())
+
+		prefixStore.Delete(oldKey)
+		prefixStore.Set([]byte(newKey), iterator.Value())
+	}
+
+	return nil
+}
+
+func migrateEthAddressByValidator(store storetypes.KVStore) error {
+	prefixStore := prefix.NewStore(store, []byte(EthAddressByValidatorKey))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		addrStr := string(iterator.Value())
+		addr := ethcmn.HexToAddress(addrStr)
+		prefixStore.Set(iterator.Key(), addr.Bytes())
+	}
+
+	return nil
+}
+
+func migrateValidatorByEthAddressKey(store storetypes.KVStore) error {
+	// TODO: There's a chance that we have duplicated keys here. We should
+	// keep only the well encoded key and discard the other. This is possible
+	// given that the all lower case keys were never accepted and no confirms
+	// made.
+	prefixStore := prefix.NewStore(store, []byte(ValidatorByEthAddressKey))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		oldKey := iterator.Key()
+		addr := ethcmn.HexToAddress(string(oldKey))
+		newKey := string(addr.Bytes())
+
+		prefixStore.Delete(oldKey)
+		if addr.Hex() != string(oldKey) {
+			// This address is not well encoded, and wasn't able to sign any
+			// claims. Thus we need to remove it (in this case skip it)
+			continue
+		}
+		prefixStore.Set([]byte(newKey), iterator.Value())
+	}
+
+	return nil
+}
+
+func migrateBatchConfirms(store storetypes.KVStore) error {
+	// previously:  BatchConfirmKey + tokenContract.GetAddress() + ConvertByteArrToString(UInt64Bytes(batchNonce)) + string(validator.Bytes())
+
+	prefixStore := prefix.NewStore(store, []byte(BatchConfirmKey))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		oldKey := iterator.Key()
+		tokenAddr := ethcmn.HexToAddress(string(oldKey[:42]))
+		newKey := tokenAddr.Bytes()
+		newKey = append(newKey, oldKey[42:]...)
+		prefixStore.Delete(oldKey)
+		prefixStore.Set([]byte(newKey), iterator.Value())
+	}
+
+	return nil
+}
+
+func migrateOutgoingTxs(store storetypes.KVStore) error {
+	prefixStore := prefix.NewStore(store, []byte(OutgoingTXPoolKey))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		oldKey := iterator.Key()
+		tokenAddr := ethcmn.HexToAddress(string(oldKey[:42]))
+		newKey := tokenAddr.Bytes()
+		newKey = append(newKey, oldKey[42:]...)
+		prefixStore.Delete(oldKey)
+		prefixStore.Set([]byte(newKey), iterator.Value())
+	}
+
+	return nil
+}
+
+func migrateOutgoingTxBatches(store storetypes.KVStore) error {
+	// OutgoingTXBatchKey + tokenContract.GetAddress() + ConvertByteArrToString(UInt64Bytes(nonce))
+	// OutgoingTXBatchKey + string(tokenContract.GetAddress().Bytes()) + ConvertByteArrToString(UInt64Bytes(nonce))
+	prefixStore := prefix.NewStore(store, []byte(OutgoingTXBatchKey))
+	iterator := prefixStore.Iterator(nil, nil)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		oldKey := iterator.Key()
+		tokenAddr := ethcmn.HexToAddress(string(oldKey[:42]))
+		newKey := tokenAddr.Bytes()
+		newKey = append(newKey, oldKey[42:]...)
+		prefixStore.Delete(oldKey)
+		prefixStore.Set(newKey, iterator.Value())
+	}
+
+	return nil
+}

--- a/module/x/gravity/migrations/v2/store_test.go
+++ b/module/x/gravity/migrations/v2/store_test.go
@@ -1,0 +1,241 @@
+package v2_test
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/Gravity-Bridge/Gravity-Bridge/module/config"
+	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/keeper"
+	v2 "github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/migrations/v2"
+	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// denomToERC20Key hasn't changed
+func oldGetDenomToERC20Key(denom string) string {
+	return v2.DenomToERC20Key + denom
+}
+
+// ERC20ToDenomKey HAS changed. Currently: ERC20ToDenomKey + string(erc20.GetAddress().Bytes())
+func oldGetERC20ToDenomKey(erc20 string) string {
+	return v2.ERC20ToDenomKey + erc20
+}
+
+func oldEthAddressByValidatorKey(validator sdk.ValAddress) string {
+	if err := sdk.VerifyAddressFormat(validator); err != nil {
+		panic(sdkerrors.Wrap(err, "invalid validator address"))
+	}
+	return v2.EthAddressByValidatorKey + string(validator.Bytes())
+}
+
+func oldGetValidatorByEthAddressKey(ethAddress string) string {
+	return v2.ValidatorByEthAddressKey + string([]byte(ethAddress))
+}
+
+func oldGetOutgoingTxPoolKey(fee types.InternalERC20Token, id uint64) string {
+	// sdkInts have a size limit of 255 bits or 32 bytes
+	// therefore this will never panic and is always safe
+	amount := make([]byte, 32)
+	amount = fee.Amount.BigInt().FillBytes(amount)
+
+	a := append(amount, types.UInt64Bytes(id)...)
+	b := append([]byte(fee.Contract.GetAddress().Hex()), a...)
+	r := append([]byte(v2.OutgoingTXPoolKey), b...)
+	return types.ConvertByteArrToString(r)
+}
+
+func oldGetOutgoingTxBatchKey(tokenContract string, nonce uint64) string {
+	return v2.OutgoingTXBatchKey + tokenContract + ConvertByteArrToString(types.UInt64Bytes(nonce))
+}
+
+func TestMigrateCosmosOriginatedDenomToERC20(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	denom := "graviton"
+	tokenContract := "0x2a24af0501a534fca004ee1bd667b783f205a546"
+	input.Context.KVStore(input.GravityStoreKey).Set([]byte(oldGetDenomToERC20Key(denom)), []byte(tokenContract))
+
+	err := v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	addr, found := input.GravityKeeper.GetCosmosOriginatedERC20(input.Context, denom)
+	assert.True(t, found)
+	// Triple check that the migration worked
+	assert.Equal(t, tokenContract, strings.ToLower(addr.GetAddress().Hex()))
+	assert.Equal(t, gethcommon.HexToAddress(tokenContract), addr.GetAddress())
+	assert.Equal(t, gethcommon.HexToAddress(tokenContract).Bytes(), addr.GetAddress().Bytes())
+}
+
+func TestMigrateCosmosOriginatedERC20ToDenom(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	denom := "graviton"
+	tokenContract := "0x2a24af0501a534fca004ee1bd667b783f205a546"
+	input.Context.KVStore(input.GravityStoreKey).Set([]byte(oldGetERC20ToDenomKey(tokenContract)), []byte(denom))
+
+	err := v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	tokenAddr, err := types.NewEthAddress(tokenContract)
+	assert.NoError(t, err)
+
+	storedDenom, found := input.GravityKeeper.GetCosmosOriginatedDenom(input.Context, *tokenAddr)
+	assert.True(t, found)
+	assert.Equal(t, denom, storedDenom)
+
+}
+
+func TestMigrateEthAddressByValidator(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	validator, err := sdk.ValAddressFromBech32("gravityvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6j77vg6")
+	assert.NoError(t, err)
+	ethAddr := "0x2a24af0501a534fca004ee1bd667b783f205a546"
+	input.Context.KVStore(input.GravityStoreKey).Set([]byte(oldEthAddressByValidatorKey(validator)), []byte(ethAddr))
+	input.Context.KVStore(input.GravityStoreKey).Set([]byte(oldEthAddressByValidatorKey(validator)), []byte(ethAddr))
+
+	err = v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	valEthAddr, found := input.GravityKeeper.GetEthAddressByValidator(input.Context, validator)
+	assert.True(t, found)
+	assert.Equal(t, ethAddr, strings.ToLower(valEthAddr.GetAddress().Hex()))
+	assert.Equal(t, gethcommon.HexToAddress(ethAddr), valEthAddr.GetAddress())
+	assert.Equal(t, gethcommon.HexToAddress(ethAddr).Bytes(), valEthAddr.GetAddress().Bytes())
+
+}
+
+func TestMigrateValidatorByEthAddressKey(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	validator, err := sdk.ValAddressFromBech32("gravityvaloper1jpz0ahls2chajf78nkqczdwwuqcu97w6j77vg6")
+	assert.NoError(t, err)
+	invalidEthAddr := "0x2a24af0501a534fca004ee1bd667b783f205a546"
+	ethAddr := "0x2a24af0501A534fcA004eE1bD667b783F205A546"
+	input.Context.KVStore(input.GravityStoreKey).
+		Set([]byte(oldGetValidatorByEthAddressKey(invalidEthAddr)), []byte(validator))
+	input.Context.KVStore(input.GravityStoreKey).
+		Set([]byte(oldGetValidatorByEthAddressKey(ethAddr)), []byte(validator))
+
+	err = v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	addr, err := types.NewEthAddress(ethAddr)
+	assert.NoError(t, err)
+
+	key := types.GetValidatorByEthAddressKey(*addr)
+	res := input.Context.KVStore(input.GravityStoreKey).Get([]byte(key))
+	assert.Equal(t, validator.Bytes(), res)
+
+	assert.Nil(t, input.Context.KVStore(input.GravityStoreKey).
+		Get([]byte(oldGetValidatorByEthAddressKey(invalidEthAddr))))
+	assert.Nil(t, input.Context.KVStore(input.GravityStoreKey).
+		Get([]byte(oldGetValidatorByEthAddressKey(ethAddr))))
+}
+
+func TestMigrateBatchConfirms(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	orch, err := sdk.AccAddressFromBech32("gravity1jpz0ahls2chajf78nkqczdwwuqcu97w6r48jzw")
+	assert.NoError(t, err)
+	ethAddr := "0x2a24af0501a534fca004ee1bd667b783f205a546"
+
+	key := v2.BatchConfirmKey + ethAddr + types.ConvertByteArrToString(types.UInt64Bytes(123)) + string(orch.Bytes())
+
+	confirm := &types.MsgConfirmBatch{
+		Nonce:         123,
+		TokenContract: ethAddr,
+		EthSigner:     "",
+		Orchestrator:  "",
+		Signature:     "",
+	}
+	confirmBytes := input.Marshaler.MustMarshal(confirm)
+	input.Context.KVStore(input.GravityStoreKey).
+		Set([]byte(key), confirmBytes)
+
+	err = v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	addr, err := types.NewEthAddress(ethAddr)
+	assert.NoError(t, err)
+
+	newKey := types.GetBatchConfirmKey(*addr, 123, orch)
+	entity := input.Context.KVStore(input.GravityStoreKey).Get([]byte(newKey))
+	assert.Equal(t, entity, confirmBytes)
+}
+
+func TestMigrateOutgoingTxs(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	addr, err := types.NewEthAddress("0x2a24af0501a534fca004ee1bd667b783f205a546")
+	assert.NoError(t, err)
+
+	outtx := &types.OutgoingTransferTx{
+		Id:          2,
+		Erc20Fee:    types.NewERC20Token(3, addr.GetAddress().Hex()),
+		Sender:      "gravity1jpz0ahls2chajf78nkqczdwwuqcu97w6r48jzw",
+		DestAddress: addr.GetAddress().Hex(),
+		Erc20Token:  types.NewERC20Token(101, addr.GetAddress().Hex()),
+	}
+
+	internalTx, err := outtx.GetErc20Fee().ToInternal()
+	assert.NoError(t, err)
+
+	oldKey := oldGetOutgoingTxPoolKey(*internalTx, outtx.Id)
+
+	inputBytes := input.Marshaler.MustMarshal(outtx)
+	input.Context.KVStore(input.GravityStoreKey).Set([]byte(oldKey), inputBytes)
+
+	err = v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	key := types.GetOutgoingTxPoolKey(*internalTx, outtx.Id)
+	res := input.Context.KVStore(input.GravityStoreKey).Get([]byte(key))
+	assert.Equal(t, inputBytes, res)
+}
+
+func TestMigrateOutgoingTxBatches(t *testing.T) {
+	input := keeper.CreateTestEnv(t)
+	defer func() { input.Context.Logger().Info("Asserting invariants at test end"); input.AssertInvariants() }()
+
+	addr, err := types.NewEthAddress("0x2a24af0501a534fca004ee1bd667b783f205a546")
+	assert.NoError(t, err)
+
+	batch := types.OutgoingTxBatch{
+		BatchNonce:    1,
+		BatchTimeout:  0,
+		Transactions:  []types.OutgoingTransferTx{},
+		TokenContract: addr.GetAddress().Hex(),
+		Block:         123,
+	}
+	assert.NoError(t, err)
+
+	oldKey := oldGetOutgoingTxBatchKey(addr.GetAddress().Hex(), batch.BatchNonce)
+
+	inputBytes := input.Marshaler.MustMarshal(&batch)
+	input.Context.KVStore(input.GravityStoreKey).Set([]byte(oldKey), inputBytes)
+
+	err = v2.MigrateStore(input.Context, input.GravityStoreKey, input.Marshaler)
+	assert.NoError(t, err)
+
+	key := types.GetOutgoingTxBatchKey(*addr, batch.BatchNonce)
+	res := input.Context.KVStore(input.GravityStoreKey).Get([]byte(key))
+	assert.Equal(t, inputBytes, res)
+}
+
+func ConvertByteArrToString(value []byte) string {
+	var ret strings.Builder
+	for i := 0; i < len(value); i++ {
+		ret.WriteString(string(value[i]))
+	}
+	return ret.String()
+}

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -106,7 +106,7 @@ type AppModule struct {
 }
 
 func (am AppModule) ConsensusVersion() uint64 {
-	return 1
+	return 2
 }
 
 // NewAppModule creates a new AppModule Object
@@ -147,6 +147,11 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+
+	m := keeper.NewMigrator(am.keeper)
+	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/gravity from version 1 to 2: %v", err))
+	}
 }
 
 // InitGenesis initializes the genesis state for this module and implements app module.

--- a/module/x/gravity/types/batch.go
+++ b/module/x/gravity/types/batch.go
@@ -63,7 +63,7 @@ func (i InternalOutgoingTransferTx) ToExternal() OutgoingTransferTx {
 	return OutgoingTransferTx{
 		Id:          i.Id,
 		Sender:      i.Sender.String(),
-		DestAddress: i.DestAddress.GetAddress(),
+		DestAddress: i.DestAddress.GetAddress().Hex(),
 		Erc20Token:  i.Erc20Token.ToExternal(),
 		Erc20Fee:    i.Erc20Fee.ToExternal(),
 	}
@@ -155,7 +155,7 @@ func (i *InternalOutgoingTxBatch) ToExternal() OutgoingTxBatch {
 		BatchNonce:    i.BatchNonce,
 		BatchTimeout:  i.BatchTimeout,
 		Transactions:  txs,
-		TokenContract: i.TokenContract.GetAddress(),
+		TokenContract: i.TokenContract.GetAddress().Hex(),
 		Block:         i.Block,
 	}
 }
@@ -173,7 +173,7 @@ func (i *InternalOutgoingTxBatches) ToExternalArray() []OutgoingTxBatch {
 			BatchNonce:    val.BatchNonce,
 			BatchTimeout:  val.BatchTimeout,
 			Transactions:  txs,
-			TokenContract: val.TokenContract.GetAddress(),
+			TokenContract: val.TokenContract.GetAddress().Hex(),
 			Block:         val.Block,
 		})
 	}
@@ -231,7 +231,7 @@ func (i InternalOutgoingTxBatch) GetCheckpoint(gravityIDstring string) []byte {
 	txFees := make([]*big.Int, len(i.Transactions))
 	for j, tx := range i.Transactions {
 		txAmounts[j] = tx.Erc20Token.Amount.BigInt()
-		txDestinations[j] = gethcommon.HexToAddress(tx.DestAddress.GetAddress())
+		txDestinations[j] = tx.DestAddress.GetAddress()
 		txFees[j] = tx.Erc20Fee.Amount.BigInt()
 	}
 
@@ -245,7 +245,7 @@ func (i InternalOutgoingTxBatch) GetCheckpoint(gravityIDstring string) []byte {
 		txDestinations,
 		txFees,
 		big.NewInt(int64(i.BatchNonce)),
-		gethcommon.HexToAddress(i.TokenContract.GetAddress()),
+		i.TokenContract.GetAddress(),
 		big.NewInt(int64(i.BatchTimeout)),
 	)
 

--- a/module/x/gravity/types/batch_test.go
+++ b/module/x/gravity/types/batch_test.go
@@ -29,18 +29,18 @@ func TestOutgoingTxBatchCheckpointGold1(t *testing.T) {
 			{
 				Id:          0x1,
 				Sender:      senderAddr.String(),
-				DestAddress: destAddress.GetAddress(),
+				DestAddress: destAddress.GetAddress().Hex(),
 				Erc20Token: ERC20Token{
 					Amount:   sdk.NewInt(0x1),
-					Contract: erc20Address.GetAddress(),
+					Contract: erc20Address.GetAddress().Hex(),
 				},
 				Erc20Fee: ERC20Token{
 					Amount:   sdk.NewInt(0x1),
-					Contract: erc20Address.GetAddress(),
+					Contract: erc20Address.GetAddress().Hex(),
 				},
 			},
 		},
-		TokenContract: erc20Address.GetAddress(),
+		TokenContract: erc20Address.GetAddress().Hex(),
 	}
 
 	// TODO: get from params

--- a/module/x/gravity/types/key.go
+++ b/module/x/gravity/types/key.go
@@ -171,7 +171,7 @@ func GetValidatorByEthAddressPrefix() string {
 // prefix              cosmos-validator
 // [0xf9][0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B]
 func GetValidatorByEthAddressKey(ethAddress EthAddress) string {
-	return GetValidatorByEthAddressPrefix() + string([]byte(ethAddress.GetAddress()))
+	return GetValidatorByEthAddressPrefix() + string(ethAddress.GetAddress().Bytes())
 }
 
 // GetValsetKey returns
@@ -260,7 +260,7 @@ func GetAttestationKey(eventNonce uint64, claimHash []byte) string {
 // [0x6][0xc783df8a850f42e7F7e57013759C285caa701eB6]
 // This prefix is used for iterating over unbatched transactions for a given contract
 func GetOutgoingTxPoolContractPrefix(contractAddress EthAddress) string {
-	return OutgoingTXPoolKey + contractAddress.GetAddress()
+	return OutgoingTXPoolKey + string(contractAddress.GetAddress().Bytes())
 }
 
 // GetOutgoingTxPoolKey returns the following key format
@@ -271,18 +271,17 @@ func GetOutgoingTxPoolKey(fee InternalERC20Token, id uint64) string {
 	// therefore this will never panic and is always safe
 	amount := make([]byte, 32)
 	amount = fee.Amount.BigInt().FillBytes(amount)
-
 	a := append(amount, UInt64Bytes(id)...)
-	b := append([]byte(fee.Contract.GetAddress()), a...)
+	b := append(fee.Contract.GetAddress().Bytes(), a...)
 	r := append([]byte(OutgoingTXPoolKey), b...)
-	return ConvertByteArrToString(r)
+	return string(r)
 }
 
 // GetOutgoingTxBatchContractPrefix returns the following format
 // prefix     eth-contract-address
 // [0xa][0xc783df8a850f42e7F7e57013759C285caa701eB6]
 func GetOutgoingTxBatchContractPrefix(tokenContract EthAddress) string {
-	return OutgoingTXBatchKey + tokenContract.GetAddress()
+	return OutgoingTXBatchKey + string(tokenContract.GetAddress().Bytes())
 }
 
 // GetOutgoingTxBatchKey returns the following key format
@@ -296,7 +295,7 @@ func GetOutgoingTxBatchKey(tokenContract EthAddress, nonce uint64) string {
 // prefix           eth-contract-address                BatchNonce
 // [0xe1][0xc783df8a850f42e7F7e57013759C285caa701eB6][0 0 0 0 0 0 0 1]
 func GetBatchConfirmNonceContractPrefix(tokenContract EthAddress, batchNonce uint64) string {
-	return BatchConfirmKey + tokenContract.GetAddress() + ConvertByteArrToString(UInt64Bytes(batchNonce))
+	return BatchConfirmKey + string(tokenContract.GetAddress().Bytes()) + ConvertByteArrToString(UInt64Bytes(batchNonce))
 }
 
 // GetBatchConfirmKey returns the following key format
@@ -333,7 +332,7 @@ func GetDenomToERC20Key(denom string) string {
 }
 
 func GetERC20ToDenomKey(erc20 EthAddress) string {
-	return ERC20ToDenomKey + erc20.GetAddress()
+	return ERC20ToDenomKey + string(erc20.GetAddress().Bytes())
 }
 
 func GetOutgoingLogicCallKey(invalidationId []byte, invalidationNonce uint64) string {

--- a/module/x/gravity/types/msgs.go
+++ b/module/x/gravity/types/msgs.go
@@ -31,7 +31,7 @@ func NewMsgSetOrchestratorAddress(val sdk.ValAddress, oper sdk.AccAddress, eth E
 	return &MsgSetOrchestratorAddress{
 		Validator:    val.String(),
 		Orchestrator: oper.String(),
-		EthAddress:   eth.GetAddress(),
+		EthAddress:   eth.GetAddress().Hex(),
 	}
 }
 
@@ -79,7 +79,7 @@ func NewMsgValsetConfirm(
 	return &MsgValsetConfirm{
 		Nonce:        nonce,
 		Orchestrator: validator.String(),
-		EthAddress:   ethAddress.GetAddress(),
+		EthAddress:   ethAddress.GetAddress().Hex(),
 		Signature:    signature,
 	}
 }
@@ -120,7 +120,7 @@ func (msg *MsgValsetConfirm) GetSigners() []sdk.AccAddress {
 func NewMsgSendToEth(sender sdk.AccAddress, destAddress EthAddress, send sdk.Coin, bridgeFee sdk.Coin) *MsgSendToEth {
 	return &MsgSendToEth{
 		Sender:    sender.String(),
-		EthDest:   destAddress.GetAddress(),
+		EthDest:   destAddress.GetAddress().Hex(),
 		Amount:    send,
 		BridgeFee: bridgeFee,
 	}


### PR DESCRIPTION
This PR changes the underlying object for EthAddress from string to geth's Address.
It also contains the necessary migrations to use the address' bytes instead of the hex representation in keys.

Closes #85 