### PR TITLE
fix: Refund now looks for denom before sending tokens

### DIFF
--- a/module/x/gravity/keeper/pool.go
+++ b/module/x/gravity/keeper/pool.go
@@ -129,7 +129,8 @@ func (k Keeper) RemoveFromOutgoingPoolAndRefund(ctx sdk.Context, txId uint64, se
 	}
 
 	// Calculate refund
-	totalToRefund := tx.Erc20Token.GravityCoin()
+	_, denom := k.ERC20ToDenomLookup(ctx, tx.Erc20Token.Contract)
+	totalToRefund := sdk.NewCoin(denom, tx.Erc20Token.Amount)
 	totalToRefund.Amount = totalToRefund.Amount.Add(tx.Erc20Fee.Amount)
 	totalToRefundCoins := sdk.NewCoins(totalToRefund)
 


### PR DESCRIPTION
Now we use `ERC20ToDenomLookup` to look for the right denom to refund instead of `.GravityCoin()`.
Please double-check if this is enough to solve the issue or if we need to add something else.

Closes #107 