### PR TITLE
Attestation order

### DIFF
--- a/module/x/gravity/keeper/attestation.go
+++ b/module/x/gravity/keeper/attestation.go
@@ -35,7 +35,7 @@ func (k Keeper) Attest(
 	// in the endBlocker.
 	lastEventNonce := k.GetLastEventNonceByValidator(ctx, valAddr)
 	if claim.GetEventNonce() != lastEventNonce+1 {
-		return nil, types.ErrNonContiguousEventNonce
+		return nil, fmt.Errorf(types.ErrNonContiguousEventNonce.Error(), lastEventNonce+1, claim.GetEventNonce())
 	}
 
 	// Tries to get an attestation with the same eventNonce and claim as the claim that was submitted.

--- a/module/x/gravity/types/errors.go
+++ b/module/x/gravity/types/errors.go
@@ -13,7 +13,7 @@ var (
 	ErrEmpty                   = sdkerrors.Register(ModuleName, 6, "empty")
 	ErrOutdated                = sdkerrors.Register(ModuleName, 7, "outdated")
 	ErrUnsupported             = sdkerrors.Register(ModuleName, 8, "unsupported")
-	ErrNonContiguousEventNonce = sdkerrors.Register(ModuleName, 9, "non contiguous event nonce")
+	ErrNonContiguousEventNonce = sdkerrors.Register(ModuleName, 9, "non contiguous event nonce, expected: %v received: %v")
 	ErrResetDelegateKeys       = sdkerrors.Register(ModuleName, 10, "can not set orchestrator addresses more than once")
 	ErrMismatched              = sdkerrors.Register(ModuleName, 11, "mismatched")
 	ErrNoValidators            = sdkerrors.Register(ModuleName, 12, "no bonded validators in active set")

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -13,7 +13,7 @@ use cosmos_gravity::{
         get_oldest_unsigned_valsets,
     },
     send::{send_batch_confirm, send_logic_call_confirm, send_valset_confirms},
-    utils::{get_last_event_nonce_with_retry},
+    utils::get_last_event_nonce_with_retry,
 };
 use deep_space::error::CosmosGrpcError;
 use deep_space::Contact;
@@ -176,9 +176,12 @@ pub async fn eth_oracle_main_loop(
             }
         }
 
+        // if the governance vote reset last event nonce sent by validator to some lower value, we can detect this
+        // by comparing last_event_nonce retrieved from the chain with last_checked_event saved by the orchestrator
+        // in order to reset last_checked_block and last_checked_event and continue from that point
         let last_event_nonce: Uint256 = get_last_event_nonce_with_retry(
             &mut grpc_client,
-            our_cosmos_address.clone(),
+            our_cosmos_address,
             contact.get_prefix().clone(),
         )
         .await
@@ -212,7 +215,10 @@ pub async fn eth_oracle_main_loop(
         .await
         {
             Ok(nonces) => {
-                // this output CheckedNonces is accurate unless a governance vote happens
+                // If the governance happened while check_for_events() was executing and there were no new event nonces,
+                // nonces.event_nonce would return lower value than last_checked_event. We want to keep last_checked_event
+                // value so it could be used in the next iteration to check if we should return to the
+                // earlier block and continue from that point. CheckedNonces is accurate unless a governance vote happens.
                 last_checked_block = nonces.block_number;
                 if nonces.event_nonce > last_checked_event {
                     last_checked_event = nonces.event_nonce;


### PR DESCRIPTION
The change in this PR solves the problem of submitting claims with unordered event nonce. This can happen if  the last_checked_event on the orchestrator side is set to 'n' and in the next iteration when check_for_events is called, there is event with the nonce 'n+1' that should be submitted but in the meantime the governance vote reset the last event nonce by the validator to 'n-1' on the chain side. 
check_for_events will try to submit event with nonce 'n+1' to the chain where last submitted nonce is set to 'n-1' and that will fail. Before this fix there was no recovery from this scenario because the last_checked_block was reset only if check_for_events returns successful result and the last event nonce on orchestrator was greater than the last event nonce on the chain side.
This check if last_checked_block should be adapted in order to replay old events is now moved before check_for_events.