### PR TITLE
Improved parallelization in submit_batches

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "docopt",
  "env_logger",
  "ethereum_gravity",
+ "futures",
  "gravity_proto",
  "gravity_utils",
  "lazy_static",

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -28,7 +28,7 @@ env_logger = "0.9"
 tokio = "1.4"
 tonic = "0.6"
 openssl-probe = "0.1"
-
+futures = "0.3"
 
 [dev-dependencies]
 actix = "0.13"

--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -232,24 +232,24 @@ async fn submit_batches(
     // do that though.
     let mut submit_possible_batch_features = Vec::new();
     for (token_type, possible_batches) in possible_batches {
-        submit_possible_batch_features.push(
-            submit_possible_batches(
-                possible_batches,
-                token_type,
-                our_ethereum_address,
-                ethereum_block_height.clone(),
-                current_valset.clone(),
-                ethereum_key,
-                web3,
-                gravity_contract_address,
-                gravity_id.clone(),
-                timeout,
-                config.clone(),
-            ));
+        submit_possible_batch_features.push(submit_possible_batches(
+            possible_batches,
+            token_type,
+            our_ethereum_address,
+            ethereum_block_height.clone(),
+            current_valset.clone(),
+            ethereum_key,
+            web3,
+            gravity_contract_address,
+            gravity_id.clone(),
+            timeout,
+            config.clone(),
+        ));
     }
     join_all(submit_possible_batch_features).await;
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn submit_possible_batches(
     possible_batches: Vec<SubmittableBatch>,
     erc20_contract: clarity::Address,
@@ -280,7 +280,7 @@ async fn submit_possible_batches(
     let latest_ethereum_batch = latest_ethereum_batch.unwrap();
 
     for batch in possible_batches {
-        submit_batch (
+        submit_batch(
             batch,
             latest_ethereum_batch,
             our_ethereum_address,
@@ -292,7 +292,8 @@ async fn submit_possible_batches(
             gravity_id.clone(),
             timeout,
             config.clone(),
-        ).await;
+        )
+        .await;
     }
 }
 
@@ -320,7 +321,9 @@ async fn submit_batch(
         return;
     }
 
-    if oldest_signed_batch.nonce <= latest_ethereum_batch { return; }
+    if oldest_signed_batch.nonce <= latest_ethereum_batch {
+        return;
+    }
 
     let oldest_signatures = batch.sigs;
     let cost = ethereum_gravity::submit_batch::estimate_tx_batch_cost(
@@ -344,7 +347,7 @@ async fn submit_batch(
         cost.gas.clone(),
         print_gwei(cost.gas_price.clone()),
         print_eth(cost.get_total())
-    );                
+    );
     oldest_signed_batch
         .display_with_eth_info(our_ethereum_address, web3)
         .await;


### PR DESCRIPTION
Changes are solving 2nd part of althea issue [althea#359](https://github.com/althea-net/cosmos-gravity-bridge/issues/359) regarding example for [batch_relaying.rs](https://github.com/Gravity-Bridge/Gravity-Bridge/blob/main/orchestrator/relayer/src/batch_relaying.rs#L232)

Parallelization is possible because different tokens are independent from each other.
There was no need for switching to different runtime like it was described in an issue since this can be solved in existing one using features and join_all.
Other than some minor changes that reduce code-depth, parallelization for submitting different tokens was enabled in [submit_batches](https://github.com/Gravity-Bridge/Gravity-Bridge/blob/main/orchestrator/relayer/src/batch_relaying.rs#L210) function.