### PR TITLE
Optimizations for integration test runtime

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,73 +7,105 @@ on:
     branches: [master, main]
 
 jobs:
-  happy-path-hardhat:
-    runs-on: ubuntu-latest
-    needs: happy-path-geth
-    steps:
-      - uses: actions/checkout@v2
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-      - name: Run all up happy-path test
-        run: tests/all-up-test.sh
-        env:
-          HARDHAT: True
   happy-path-geth:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Prune cache to keep the size down
         run: docker builder prune -af && docker system prune -af
       - name: Run all up happy-path test
         run: tests/all-up-test.sh
+  happy-path-hardhat:
+    runs-on: ubuntu-latest
+    needs: happy-path-geth
+    steps:
+      - uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
+      - name: Run all up happy-path test
+        run: tests/all-up-test.sh
+        env:
+          HARDHAT: True
+          NO_IMAGE_BUILD: True
   validator-out:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run all up test with a validator out
         run: tests/all-up-test.sh VALIDATOR_OUT
+        env:
+          NO_IMAGE_BUILD: True
   valset-stress:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run all up valset stress test
         run: tests/all-up-test.sh VALSET_STRESS
+        env:
+          NO_IMAGE_BUILD: True
   batch-stress:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run all up batch stress test
         run: tests/all-up-test.sh BATCH_STRESS
+        env:
+          NO_IMAGE_BUILD: True
   v2-happy-path:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run all up batch stress test
         run: tests/all-up-test.sh V2_HAPPY_PATH
+        env:
+          NO_IMAGE_BUILD: True
   relay-market:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run all up relay market test
         env:
           ALCHEMY_ID: ${{ secrets.ALCHEMY_ID }}
+          NO_IMAGE_BUILD: True
         if: ${{ env.ALCHEMY_ID != '' }}
         run: tests/all-up-test.sh RELAY_MARKET $ALCHEMY_ID
   orchestrator-keys:
@@ -82,123 +114,193 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run orchestrator key setting test
         run: tests/all-up-test.sh ORCHESTRATOR_KEYS
+        env:
+          NO_IMAGE_BUILD: True
   valset_update_rewards:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run the validator set update rewards test
         run: tests/all-up-test.sh VALSET_REWARDS
+        env:
+          NO_IMAGE_BUILD: True
   evidence_based_slashing:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run the evidence based slashing test
         run: tests/all-up-test.sh EVIDENCE
+        env:
+          NO_IMAGE_BUILD: True
   transaction-cancel:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Run the transaction cancel test
         run: tests/all-up-test.sh TXCANCEL
+        env:
+          NO_IMAGE_BUILD: True
   invalid-events:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Submit invalid events
         run: tests/all-up-test.sh INVALID_EVENTS
+        env:
+          NO_IMAGE_BUILD: True
   unhalt-bridge:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Halt bridge with ETH hardfork and then unhalt the bridge via governance
         run: tests/all-up-test.sh UNHALT_BRIDGE
+        env:
+          NO_IMAGE_BUILD: True
   pause-bridge:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Pause and then resume the bridge via governance
         run: tests/all-up-test.sh PAUSE_BRIDGE
+        env:
+          NO_IMAGE_BUILD: True
   deposit-overflow:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Submit an overflowing deposit
         run: tests/all-up-test.sh DEPOSIT_OVERFLOW
+        env:
+          NO_IMAGE_BUILD: True
   ethereum-blacklist:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Attempt to deposit to a blacklisted address
         run: tests/all-up-test.sh ETHEREUM_BLACKLIST
+        env:
+          NO_IMAGE_BUILD: True
   airdrop_proposal:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Execute a governance powered airdrop
         run: tests/all-up-test.sh AIRDROP_PROPOSAL
+        env:
+          NO_IMAGE_BUILD: True
   signature_slashing:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Test slashing for unsubmitted signatures
         run: tests/all-up-test.sh SIGNATURE_SLASHING
+        env:
+          NO_IMAGE_BUILD: True
   slashing_delegation:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Test delegation after slashing
         run: tests/all-up-test.sh SLASHING_DELEGATION
+        env:
+          NO_IMAGE_BUILD: True
   ibc_metadata:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Test setting metadata for IBC tokens
         run: tests/all-up-test.sh IBC_METADATA
+        env:
+          NO_IMAGE_BUILD: True
   erc721_happy_path:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
       - name: Test ERC721 happy path
         run: tests/all-up-test.sh ERC721_HAPPY_PATH
+        env:
+          NO_IMAGE_BUILD: True

--- a/tests/all-up-test.sh
+++ b/tests/all-up-test.sh
@@ -6,12 +6,15 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # builds the container containing various system deps
 # also builds Gravity once in order to cache Go deps, this container
-# must be rebuilt every time you run this test if you want a faster
-# solution use start chains and then run tests
-# note, this container does not need to be rebuilt to test the same code
-# twice, docker will automatically detect and cache this case, no need
-# for that logic here
+# must be rebuilt every time you run this test because it pulls in the
+# current repo state by reading the latest git commit during image creation
+# if you want a faster solution use start chains and then run tests
+# if you are running many tests on the same code set the NO_IMAGE_BUILD=1 env var
+set +u
+if [[ -z ${NO_IMAGE_BUILD} ]]; then
 bash $DIR/build-container.sh
+fi
+set -u
 
 # Remove existing container instance
 set +e

--- a/tests/container-scripts/all-up-test-internal.sh
+++ b/tests/container-scripts/all-up-test-internal.sh
@@ -5,11 +5,6 @@ TEST_TYPE=$2
 ALCHEMY_ID=$3
 set -eux
 
-# Prepare the contracts for later deployment
-pushd /gravity/solidity/
-HUSKY_SKIP_INSTALL=1 npm install
-npm run typechain
-
 bash /gravity/tests/container-scripts/setup-validators.sh $NODES
 
 bash /gravity/tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE $ALCHEMY_ID &

--- a/tests/dockerfile/Dockerfile
+++ b/tests/dockerfile/Dockerfile
@@ -9,7 +9,7 @@ RUN cd /geth && tar -xvf * && mv /geth/**/geth /usr/bin/geth
 # the actual source code for this repo, this **only** includes checked in files!
 # this is a bit of a pain but it does speed things up a lot
 ADD gravity.tar.gz /
-# build steps for all codebases in this repo, must be below the add statement
-RUN pushd /gravity/orchestrator/ && PATH=$PATH:$HOME/.cargo/bin cargo build --all --release
+# build the test runner specifically to cache a release artifact
+RUN pushd /gravity/orchestrator/test_runner && PATH=$PATH:$HOME/.cargo/bin cargo build --bin test-runner --release
 RUN pushd /gravity/module/ && PATH=$PATH:/usr/local/go/bin GOPROXY=https://proxy.golang.org make && PATH=$PATH:/usr/local/go/bin make install
-RUN pushd /gravity/solidity/ && npm ci
+RUN pushd /gravity/solidity/ && HUSKY_SKIP_INSTALL=1 npm install && npm run typechain


### PR DESCRIPTION
This patch adds a new env flag NO_BUILD_IMAGE which prevents building an
image when running the all-up-test.sh this should dramatically reduce
the runtime of our integration tests by only having the happy path geth
test build the docker container.

Another minor fix made here is to move the solidity contract building into
the container and out of the all-up-test-internal.sh so that it can also
only be run once.

Finally we build the test runner specifically rather than the entire orchestrator folder. Reducing the amount of re-building that goes on each image run.