### PR TITLE
Make test setup accessible externally

### DIFF
--- a/tests/container-scripts/run-testnet.sh
+++ b/tests/container-scripts/run-testnet.sh
@@ -29,6 +29,9 @@ do
         RPC_ADDRESS="--rpc.laddr tcp://0.0.0.0:26657"
         GRPC_ADDRESS="--grpc.address 0.0.0.0:9090"
         GRPC_WEB_ADDRESS="--grpc-web.address 0.0.0.0:9092"
+        sed -i 's/enable-unsafe-cors = false/enable-unsafe-cors = true/g' /validator$i/config/app.toml
+        sed -i 's/enabled-unsafe-cors = false/enabled-unsafe-cors = true/g' /validator$i/config/app.toml
+        sed -i 's/enable = false/enable = true/g' /validator$i/config/app.toml #enables more than we want, but will work for now
     else
         # move these to another port and address, not becuase they will
         # be used there, but instead to prevent them from causing problems

--- a/tests/start-chains.sh
+++ b/tests/start-chains.sh
@@ -32,4 +32,4 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
        PLATFORM_CMD="--platform=linux/amd64"; fi
 fi
 # Run new test container instance
-docker run --name gravity_test_instance $PLATFORM_CMD --mount type=bind,source="$(pwd)"/,target=/gravity --cap-add=NET_ADMIN -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it gravity-base /bin/bash /gravity/tests/container-scripts/reload-code.sh $NODES $TEST_TYPE $ALCHEMY_ID
+docker run --name gravity_test_instance $PLATFORM_CMD --mount type=bind,source="$(pwd)"/,target=/gravity --cap-add=NET_ADMIN -p 9092:9092 -p 9090:9090 -p 26657:26657 -p 1317:1317 -p 8545:8545 -it gravity-base /bin/bash /gravity/tests/container-scripts/reload-code.sh $NODES $TEST_TYPE $ALCHEMY_ID


### PR DESCRIPTION
Hey there I changed the test scripts so everything can be accessed externally. And cors is enabled. This allows for easier development of gravity tools. 