### PR TITLE
Add no-op mercury2.0 upgrade handler

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -315,7 +315,7 @@ jobs:
           restore-keys: |
             integration-test-cache-
       - name: Test Mercury state upgrade
-        run: tests/run-upgrade-test.sh v1.4.3-beta
+        run: tests/run-upgrade-test.sh v1.5.0
         env:
           NO_IMAGE_BUILD: True
   ibc_auto_forward_test:

--- a/module/app/upgrades/register.go
+++ b/module/app/upgrades/register.go
@@ -1,8 +1,6 @@
 package upgrades
 
 import (
-	"fmt"
-
 	"github.com/cosmos/cosmos-sdk/types/module"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
@@ -23,7 +21,6 @@ func RegisterUpgradeHandlers(
 	bankKeeper *bankkeeper.BaseKeeper, bech32IbcKeeper *bech32ibckeeper.Keeper, distrKeeper *distrkeeper.Keeper,
 	mintKeeper *mintkeeper.Keeper, stakingKeeper *stakingkeeper.Keeper, upgradeKeeper *upgradekeeper.Keeper,
 ) {
-	fmt.Println("Enter RegisterUpgradeHandlers")
 	if mm == nil || configurator == nil || accountKeeper == nil || bankKeeper == nil || bech32IbcKeeper == nil ||
 		distrKeeper == nil || mintKeeper == nil || stakingKeeper == nil || upgradeKeeper == nil {
 		panic("Nil argument to RegisterUpgradeHandlers()!")
@@ -32,5 +29,10 @@ func RegisterUpgradeHandlers(
 	upgradeKeeper.SetUpgradeHandler(
 		v2.V1ToV2PlanName, // Codename Mercury
 		v2.GetV2UpgradeHandler(mm, configurator, accountKeeper, bankKeeper, bech32IbcKeeper, distrKeeper, mintKeeper, stakingKeeper),
+	)
+	// Mercury Fix aka mercury2.0 UPGRADE HANDLER SETUP
+	upgradeKeeper.SetUpgradeHandler(
+		v2.V2FixPlanName, // mercury2.0
+		v2.GetMercury2Dot0UpgradeHandler(),
 	)
 }

--- a/module/app/upgrades/v2/constants.go
+++ b/module/app/upgrades/v2/constants.go
@@ -1,3 +1,4 @@
 package v2
 
 var V1ToV2PlanName = "mercury"
+var V2FixPlanName = "mercury2.0"

--- a/module/app/upgrades/v2/handler.go
+++ b/module/app/upgrades/v2/handler.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -18,6 +17,24 @@ import (
 	gravitytypes "github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
 )
 
+// GetMercury2Dot0UpgradeHandler Creates the handler for "mercury2.0", where we fix the mercury upgrade's
+// implementation of IBC Auto Forwarding
+// Note: mercury2.0 is not a consensus breaking change, as it only enables new functionality which is so far unused,
+// thus it is unnecessary to change the consensus version or create a new upgrades module
+func GetMercury2Dot0UpgradeHandler() func(
+	ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap,
+) (module.VersionMap, error) {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("Performing Fix for Mercury IBC Auto-Forwarding")
+		// This upgrade introduces a new hash(PendingIbcAutoForward) key into the gravity store as IBC Auto-Forwards
+		// are queued. This key will only be populated or used upon the creation of the first IBC Auto-Forward.
+		// In short, there is no actual work to be performed here, but the messages make it quite clear that the upgrade
+		// ran, and the new code is running as expected.
+		ctx.Logger().Info("Upgrade Complete!")
+		return vmap, nil
+	}
+}
+
 func GetV2UpgradeHandler(
 	mm *module.Manager, configurator *module.Configurator, accountKeeper *authkeeper.AccountKeeper,
 	bankKeeper *bankkeeper.BaseKeeper, bech32IbcKeeper *bech32ibckeeper.Keeper, distrKeeper *distrkeeper.Keeper,
@@ -25,7 +42,6 @@ func GetV2UpgradeHandler(
 ) func(
 	ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap,
 ) (module.VersionMap, error) {
-	fmt.Println("Enter GetV2UpgradeHandler")
 	if mm == nil || configurator == nil || accountKeeper == nil || bankKeeper == nil || bech32IbcKeeper == nil ||
 		distrKeeper == nil || mintKeeper == nil || stakingKeeper == nil {
 		panic("Nil argument to GetV2UpgradeHandler")

--- a/orchestrator/cosmos_gravity/src/query.rs
+++ b/orchestrator/cosmos_gravity/src/query.rs
@@ -317,12 +317,15 @@ pub async fn get_all_pending_ibc_auto_forwards(
     let pending_forwards = grpc_client
         .get_pending_ibc_auto_forwards(QueryPendingIbcAutoForwards { limit: 0 })
         .await;
-    if pending_forwards.is_err() {
-        let status = pending_forwards.err().unwrap();
-        warn!(
-            "Received an error when querying for pending ibc auto forwards: {}",
-            status.message()
-        );
+    if let Err(status) = pending_forwards {
+        // don't print errors during the upgrade test, which involves running
+        // a newer orchestrator against an older chain due to current design limitations.
+        if !status.message().contains("unknown method") {
+            warn!(
+                "Received an error when querying for pending ibc auto forwards: {}",
+                status.message()
+            );
+        }
         return vec![];
     }
 

--- a/orchestrator/test_runner/src/bootstrapping.rs
+++ b/orchestrator/test_runner/src/bootstrapping.rs
@@ -76,6 +76,7 @@ fn parse_phrases(filename: &str) -> (Vec<CosmosPrivateKey>, Vec<String>) {
 /// that we have one key for each validator in this file.
 pub fn parse_validator_keys() -> (Vec<CosmosPrivateKey>, Vec<String>) {
     let filename = "/validator-phrases";
+    info!("Reading mnemonics from {}", filename);
     parse_phrases(filename)
 }
 
@@ -83,6 +84,7 @@ pub fn parse_validator_keys() -> (Vec<CosmosPrivateKey>, Vec<String>) {
 /// over IBC for testing purposes
 pub fn parse_ibc_validator_keys() -> (Vec<CosmosPrivateKey>, Vec<String>) {
     let filename = "/ibc-validator-phrases";
+    info!("Reading mnemonics from {}", filename);
     parse_phrases(filename)
 }
 
@@ -91,6 +93,7 @@ pub fn parse_ibc_validator_keys() -> (Vec<CosmosPrivateKey>, Vec<String>) {
 /// similar file /orchestrator-phrases
 pub fn parse_orchestrator_keys() -> Vec<CosmosPrivateKey> {
     let filename = "/orchestrator-phrases";
+    info!("Reading orchestrator phrases from {}", filename);
     let (orch_keys, _) = parse_phrases(filename);
     orch_keys
 }

--- a/orchestrator/test_runner/src/upgrade.rs
+++ b/orchestrator/test_runner/src/upgrade.rs
@@ -53,10 +53,10 @@ pub async fn upgrade_part_1(
         None,
         UpgradeProposalParams {
             upgrade_height,
-            plan_name: "mercury".to_string(),
-            plan_info: "mercury upgrade info here".to_string(),
-            proposal_title: "mercury upgrade proposal title here".to_string(),
-            proposal_desc: "mercury upgrade proposal description here".to_string(),
+            plan_name: "mercury2.0".to_string(),
+            plan_info: "mercury2.0 upgrade info here".to_string(),
+            proposal_title: "mercury2.0 upgrade proposal title here".to_string(),
+            proposal_desc: "mercury2.0 upgrade proposal description here".to_string(),
         },
     )
     .await;

--- a/tests/container-scripts/upgrade-test-internal.sh
+++ b/tests/container-scripts/upgrade-test-internal.sh
@@ -24,6 +24,7 @@ make
 make install
 cd /gravity/
 tests/container-scripts/setup-validators.sh $NODES
+tests/container-scripts/setup-ibc-validators.sh $NODES
 
 # Run the old binary
 tests/container-scripts/run-testnet.sh $NODES


### PR DESCRIPTION
While not necessary for the upgrade to process correctly, this
mercury2.0 upgrade handler will show to validators that the upgrade has
been completed successfully, and solve the issue of performing the
upgrade with `--unsafe-skip-upgrades` when no handler is registered.