### PR TITLE
Fix RUN_ORCH_ONLY test_runner

### DIFF
--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -39,6 +39,7 @@ use tokio::time::sleep;
 use transaction_stress_test::transaction_stress_test;
 use unhalt_bridge::unhalt_bridge_test;
 use valset_stress::validator_set_stress_test;
+use orch_only::orch_only_test;
 
 mod airdrop_proposal;
 mod bootstrapping;
@@ -63,6 +64,7 @@ mod upgrade;
 mod utils;
 mod valset_rewards;
 mod valset_stress;
+mod orch_only;
 
 /// the timeout for individual requests
 const OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
@@ -464,6 +466,7 @@ pub async fn main() {
             .await;
             return;
         } else if test_type == "RUN_ORCH_ONLY" {
+            orch_only_test(keys, gravity_address).await;
             sleep(Duration::from_secs(1_000_000_000)).await;
             return;
         } else if !test_type.is_empty() {

--- a/orchestrator/test_runner/src/orch_only.rs
+++ b/orchestrator/test_runner/src/orch_only.rs
@@ -1,0 +1,12 @@
+use crate::utils::create_default_test_config;
+use crate::utils::start_orchestrators;
+use crate::utils::ValidatorKeys;
+use clarity::Address as EthAddress;
+
+pub async fn orch_only_test(
+    keys: Vec<ValidatorKeys>,
+    gravity_address: EthAddress,
+) {
+    let no_relay_market_config = create_default_test_config();
+    start_orchestrators(keys.clone(), gravity_address, false, no_relay_market_config).await;
+}


### PR DESCRIPTION
This PR adds a fix on top of PR #172 which was meant to run the orchestrators without running any particular test case. The fix is simply to run the `start_orchestrators` furnction.

Tested this by running the test_runner locally with `./tests/run-tests.sh RUN_ORCH_ONLY` and then manually bridging funds from the Ethereum chain to the Cosmos chain.