### PR TITLE
Fix error returned when recipient is in the blacklist

### DIFF
--- a/module/x/gravity/keeper/msg_server.go
+++ b/module/x/gravity/keeper/msg_server.go
@@ -135,7 +135,7 @@ func (k msgServer) SendToEth(c context.Context, msg *types.MsgSendToEth) (*types
 	}
 
 	if k.InvalidSendToEthAddress(ctx, *dest, *erc20) {
-		return nil, sdkerrors.Wrap(err, "destination address is invalid or blacklisted")
+		return nil, sdkerrors.Wrap(types.ErrInvalid, "destination address is invalid or blacklisted")
 	}
 
 	txID, err := k.AddToOutgoingPool(ctx, sender, *dest, msg.Amount, msg.BridgeFee)


### PR DESCRIPTION
The current code would eventually panic 

```
err = nil
sdkerrors.Wrap(err, "destination address is invalid or blacklisted") = nil
```