### PR TITLE
Oracle bundling fix

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -25,6 +25,10 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
+        
+      - uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: orchestrator/
 
       - name: Set ENV var for GOPATH
         run: |
@@ -119,7 +123,6 @@ jobs:
       - name: Build GBT ARM64
         run: |
           cd orchestrator
-          cargo clean
           cross build --target aarch64-unknown-linux-musl --release
 
       - name: Upload Gravity Bridge Tools ARM
@@ -136,7 +139,6 @@ jobs:
       - name: Build GBT Windows
         run: |
           cd orchestrator
-          cargo clean
           cross build --target x86_64-pc-windows-gnu --release
 
       - name: Upload Gravity Bridge Tools Windows
@@ -176,7 +178,6 @@ jobs:
           CC=o64-clang \
           CXX=o64-clang++ \
           LIBZ_SYS_STATIC=1 \
-          cargo clean
           cargo build --target x86_64-apple-darwin --release
 
       - name: Upload Gravity Bridge Tools Mac

--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -310,11 +310,20 @@ pub async fn send_ethereum_claims(
     for (key, _) in unordered_msgs.iter() {
         keys.push(*key);
     }
+    // sorts ascending by default
     keys.sort_unstable();
 
+    const MAX_ORACLE_MESSAGES: usize = 1000;
     let mut msgs = Vec::new();
     for i in keys {
+        // pushes messages with a later nonce onto the end
         msgs.push(unordered_msgs.remove_entry(&i).unwrap().1);
+    }
+    // prevents the message buffer from getting too big if a lot of events
+    // are left in a validators queue
+    while msgs.len() > MAX_ORACLE_MESSAGES {
+        // pops messages off of the end
+        msgs.pop();
     }
 
     contact

--- a/orchestrator/gravity_proto/src/prost/gravity.v1.rs
+++ b/orchestrator/gravity_proto/src/prost/gravity.v1.rs
@@ -7,7 +7,7 @@ pub enum SignType {
     OrchestratorSignedWithdrawBatch = 2,
 }
 /// BridgeValidator represents a validator's ETH address and its power
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct BridgeValidator {
     #[prost(uint64, tag="1")]
     pub power: u64,
@@ -17,7 +17,7 @@ pub struct BridgeValidator {
 /// Valset is the Ethereum Bridge Multsig Set, each gravity validator also
 /// maintains an ETH key to sign messages, these are used to check signatures on
 /// ETH because of the significant gas savings
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct Valset {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
@@ -36,7 +36,7 @@ pub struct Valset {
 /// it was observed at. These two numbers can be used to project
 /// outward and always produce batches with timeouts in the future
 /// even if no Ethereum block height has been relayed for a long time
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct LastObservedEthereumBlockHeight {
     #[prost(uint64, tag="1")]
     pub cosmos_block_height: u64,
@@ -45,7 +45,7 @@ pub struct LastObservedEthereumBlockHeight {
 }
 /// This records the relationship between an ERC20 token and the denom
 /// of the corresponding Cosmos originated asset
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct Erc20ToDenom {
     #[prost(string, tag="1")]
     pub erc20: ::prost::alloc::string::String,
@@ -58,7 +58,7 @@ pub struct Erc20ToDenom {
 /// handling of cases where for example an Ethereum hardfork has occured and more than 1/3 of the vlaidtor set
 /// disagrees with the rest. Normally this would require a chain halt, manual genesis editing and restar to resolve
 /// with this feature a governance proposal can be used instead
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct UnhaltBridgeProposal {
     #[prost(string, tag="1")]
     pub title: ::prost::alloc::string::String,
@@ -71,7 +71,7 @@ pub struct UnhaltBridgeProposal {
 /// fashion. A list of destination addresses and an amount per airdrop recipient is provided. The funds for this
 /// airdrop are removed from the Community Pool, if the community pool does not have sufficient funding to perform
 /// the airdrop to all provided recipients nothing will occur
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct AirdropProposal {
     #[prost(string, tag="1")]
     pub title: ::prost::alloc::string::String,
@@ -134,7 +134,7 @@ pub struct PendingIbcAutoForward {
 /// ETH_ADDRESS
 /// This is a hex encoded 0x Ethereum public key that will be used by this validator
 /// on Ethereum
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgSetOrchestratorAddress {
     #[prost(string, tag="1")]
     pub validator: ::prost::alloc::string::String,
@@ -143,7 +143,7 @@ pub struct MsgSetOrchestratorAddress {
     #[prost(string, tag="3")]
     pub eth_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgSetOrchestratorAddressResponse {
 }
 /// MsgValsetConfirm
@@ -161,7 +161,7 @@ pub struct MsgSetOrchestratorAddressResponse {
 /// signatures it is then possible for anyone to view these signatures in the
 /// chain store and submit them to Ethereum to update the validator set
 /// -------------
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgValsetConfirm {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
@@ -172,7 +172,7 @@ pub struct MsgValsetConfirm {
     #[prost(string, tag="4")]
     pub signature: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgValsetConfirmResponse {
 }
 /// MsgSendToEth
@@ -198,7 +198,7 @@ pub struct MsgSendToEth {
     #[prost(message, optional, tag="4")]
     pub bridge_fee: ::core::option::Option<cosmos_sdk_proto::cosmos::base::v1beta1::Coin>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgSendToEthResponse {
 }
 /// MsgRequestBatch
@@ -210,14 +210,14 @@ pub struct MsgSendToEthResponse {
 /// batch, sign it, submit the signatures with a MsgConfirmBatch before a relayer
 /// can finally submit the batch
 /// -------------
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgRequestBatch {
     #[prost(string, tag="1")]
     pub sender: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub denom: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgRequestBatchResponse {
 }
 /// MsgConfirmBatch
@@ -228,7 +228,7 @@ pub struct MsgRequestBatchResponse {
 /// (TODO determine this without nondeterminism) This message includes the batch
 /// as well as an Ethereum signature over this batch by the validator
 /// -------------
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgConfirmBatch {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
@@ -241,7 +241,7 @@ pub struct MsgConfirmBatch {
     #[prost(string, tag="5")]
     pub signature: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgConfirmBatchResponse {
 }
 /// MsgConfirmLogicCall
@@ -252,7 +252,7 @@ pub struct MsgConfirmBatchResponse {
 /// (TODO determine this without nondeterminism) This message includes the batch
 /// as well as an Ethereum signature over this batch by the validator
 /// -------------
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgConfirmLogicCall {
     #[prost(string, tag="1")]
     pub invalidation_id: ::prost::alloc::string::String,
@@ -265,7 +265,7 @@ pub struct MsgConfirmLogicCall {
     #[prost(string, tag="5")]
     pub signature: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgConfirmLogicCallResponse {
 }
 /// MsgSendToCosmosClaim
@@ -273,7 +273,7 @@ pub struct MsgConfirmLogicCallResponse {
 /// claimed to have seen the deposit enter the ethereum blockchain coins are
 /// issued to the Cosmos address in question
 /// -------------
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgSendToCosmosClaim {
     #[prost(uint64, tag="1")]
     pub event_nonce: u64,
@@ -290,14 +290,14 @@ pub struct MsgSendToCosmosClaim {
     #[prost(string, tag="7")]
     pub orchestrator: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgSendToCosmosClaimResponse {
 }
 /// MsgExecuteIbcAutoForwards
 /// Prompts the forwarding of Pending IBC Auto-Forwards in the queue
 /// The Pending forwards will be executed in order of their original SendToCosmos.EventNonce
 /// The funds in the queue will be sent to a local gravity-prefixed address if IBC transfer is not possible
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgExecuteIbcAutoForwards {
     /// How many queued forwards to clear, be careful about gas limits
     #[prost(uint64, tag="1")]
@@ -306,12 +306,12 @@ pub struct MsgExecuteIbcAutoForwards {
     #[prost(string, tag="2")]
     pub executor: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgExecuteIbcAutoForwardsResponse {
 }
 /// BatchSendToEthClaim claims that a batch of send to eth
 /// operations on the bridge contract was executed.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgBatchSendToEthClaim {
     #[prost(uint64, tag="1")]
     pub event_nonce: u64,
@@ -324,13 +324,13 @@ pub struct MsgBatchSendToEthClaim {
     #[prost(string, tag="5")]
     pub orchestrator: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgBatchSendToEthClaimResponse {
 }
 /// ERC20DeployedClaim allows the Cosmos module
 /// to learn about an ERC20 that someone deployed
 /// to represent a Cosmos asset
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgErc20DeployedClaim {
     #[prost(uint64, tag="1")]
     pub event_nonce: u64,
@@ -349,12 +349,12 @@ pub struct MsgErc20DeployedClaim {
     #[prost(string, tag="8")]
     pub orchestrator: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgErc20DeployedClaimResponse {
 }
 /// This informs the Cosmos module that a logic
 /// call has been executed
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgLogicCallExecutedClaim {
     #[prost(uint64, tag="1")]
     pub event_nonce: u64,
@@ -367,12 +367,12 @@ pub struct MsgLogicCallExecutedClaim {
     #[prost(string, tag="5")]
     pub orchestrator: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgLogicCallExecutedClaimResponse {
 }
 /// This informs the Cosmos module that a validator
 /// set has been updated.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgValsetUpdatedClaim {
     #[prost(uint64, tag="1")]
     pub event_nonce: u64,
@@ -389,20 +389,20 @@ pub struct MsgValsetUpdatedClaim {
     #[prost(string, tag="7")]
     pub orchestrator: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgValsetUpdatedClaimResponse {
 }
 /// This call allows the sender (and only the sender)
 /// to cancel a given MsgSendToEth and recieve a refund
 /// of the tokens
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgCancelSendToEth {
     #[prost(uint64, tag="1")]
     pub transaction_id: u64,
     #[prost(string, tag="2")]
     pub sender: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgCancelSendToEthResponse {
 }
 /// This call allows anyone to submit evidence that a
@@ -418,43 +418,43 @@ pub struct MsgSubmitBadSignatureEvidence {
     #[prost(string, tag="3")]
     pub sender: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct MsgSubmitBadSignatureEvidenceResponse {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventSetOperatorAddress {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventValsetConfirmKey {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub key: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventBatchCreated {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub batch_nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventBatchConfirmKey {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub batch_confirm_key: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventBatchSendToEthClaim {
     #[prost(string, tag="1")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventClaim {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
@@ -463,7 +463,7 @@ pub struct EventClaim {
     #[prost(string, tag="3")]
     pub attestation_id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventBadSignatureEvidence {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
@@ -472,19 +472,19 @@ pub struct EventBadSignatureEvidence {
     #[prost(string, tag="3")]
     pub bad_eth_signature_subject: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventErc20DeployedClaim {
     #[prost(string, tag="1")]
     pub token: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventValsetUpdatedClaim {
     #[prost(string, tag="1")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventMultisigUpdateRequest {
     #[prost(string, tag="1")]
     pub bridge_contract: ::prost::alloc::string::String,
@@ -495,21 +495,21 @@ pub struct EventMultisigUpdateRequest {
     #[prost(string, tag="4")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventOutgoingLogicCallCanceled {
     #[prost(string, tag="1")]
     pub logic_call_invalidation_id: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub logic_call_invalidation_nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventSignatureSlashing {
     #[prost(string, tag="1")]
     pub r#type: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventOutgoingTxId {
     #[prost(string, tag="1")]
     pub message: ::prost::alloc::string::String,
@@ -901,14 +901,14 @@ pub struct Attestation {
 /// The contract address on ETH of the token, this could be a Cosmos
 /// originated token, if so it will be the ERC20 address of the representation
 /// (note: developers should look up the token symbol using the address on ETH to display for UI)
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct Erc20Token {
     #[prost(string, tag="1")]
     pub contract: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub amount: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventObservation {
     #[prost(string, tag="1")]
     pub attestation_type: ::prost::alloc::string::String,
@@ -921,7 +921,7 @@ pub struct EventObservation {
     #[prost(string, tag="5")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventInvalidSendToCosmosReceiver {
     #[prost(string, tag="1")]
     pub amount: ::prost::alloc::string::String,
@@ -932,7 +932,7 @@ pub struct EventInvalidSendToCosmosReceiver {
     #[prost(string, tag="4")]
     pub sender: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventSendToCosmos {
     #[prost(string, tag="1")]
     pub amount: ::prost::alloc::string::String,
@@ -941,7 +941,7 @@ pub struct EventSendToCosmos {
     #[prost(string, tag="3")]
     pub token: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventSendToCosmosLocal {
     #[prost(string, tag="1")]
     pub nonce: ::prost::alloc::string::String,
@@ -952,7 +952,7 @@ pub struct EventSendToCosmosLocal {
     #[prost(string, tag="4")]
     pub amount: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventSendToCosmosPendingIbcAutoForward {
     #[prost(string, tag="1")]
     pub nonce: ::prost::alloc::string::String,
@@ -965,7 +965,7 @@ pub struct EventSendToCosmosPendingIbcAutoForward {
     #[prost(string, tag="5")]
     pub channel: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventSendToCosmosExecutedIbcAutoForward {
     #[prost(string, tag="1")]
     pub nonce: ::prost::alloc::string::String,
@@ -996,7 +996,7 @@ pub enum ClaimType {
     ValsetUpdated = 5,
 }
 /// OutgoingTxBatch represents a batch of transactions going from gravity to ETH
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct OutgoingTxBatch {
     #[prost(uint64, tag="1")]
     pub batch_nonce: u64,
@@ -1010,7 +1010,7 @@ pub struct OutgoingTxBatch {
     pub block: u64,
 }
 /// OutgoingTransferTx represents an individual send from gravity to ETH
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct OutgoingTransferTx {
     #[prost(uint64, tag="1")]
     pub id: u64,
@@ -1024,7 +1024,7 @@ pub struct OutgoingTransferTx {
     pub erc20_fee: ::core::option::Option<Erc20Token>,
 }
 /// OutgoingLogicCall represents an individual logic call from gravity to ETH
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct OutgoingLogicCall {
     #[prost(message, repeated, tag="1")]
     pub transfers: ::prost::alloc::vec::Vec<Erc20Token>,
@@ -1043,7 +1043,7 @@ pub struct OutgoingLogicCall {
     #[prost(uint64, tag="8")]
     pub block: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventOutgoingBatchCanceled {
     #[prost(string, tag="1")]
     pub bridge_contract: ::prost::alloc::string::String,
@@ -1054,7 +1054,7 @@ pub struct EventOutgoingBatchCanceled {
     #[prost(string, tag="4")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventOutgoingBatch {
     #[prost(string, tag="1")]
     pub bridge_contract: ::prost::alloc::string::String,
@@ -1224,7 +1224,7 @@ pub struct GenesisState {
     pub unbatched_transfers: ::prost::alloc::vec::Vec<OutgoingTransferTx>,
 }
 /// GravityCounters contains the many noces and counters required to maintain the bridge state in the genesis
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct GravityNonces {
     /// the nonce of the last generated validator set
     #[prost(uint64, tag="1")]
@@ -1253,12 +1253,12 @@ pub struct GravityNonces {
     pub last_batch_id: u64,
 }
 /// IDSet represents a set of IDs
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct IdSet {
     #[prost(uint64, repeated, tag="1")]
     pub ids: ::prost::alloc::vec::Vec<u64>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct BatchFees {
     #[prost(string, tag="1")]
     pub token: ::prost::alloc::string::String,
@@ -1267,7 +1267,7 @@ pub struct BatchFees {
     #[prost(uint64, tag="3")]
     pub tx_count: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventWithdrawalReceived {
     #[prost(string, tag="1")]
     pub bridge_contract: ::prost::alloc::string::String,
@@ -1278,7 +1278,7 @@ pub struct EventWithdrawalReceived {
     #[prost(string, tag="4")]
     pub nonce: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct EventWithdrawCanceled {
     #[prost(string, tag="1")]
     pub sender: ::prost::alloc::string::String,
@@ -1289,7 +1289,7 @@ pub struct EventWithdrawCanceled {
     #[prost(string, tag="4")]
     pub bridge_chain_id: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryParamsRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1297,172 +1297,172 @@ pub struct QueryParamsResponse {
     #[prost(message, optional, tag="1")]
     pub params: ::core::option::Option<Params>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryCurrentValsetRequest {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryCurrentValsetResponse {
     #[prost(message, optional, tag="1")]
     pub valset: ::core::option::Option<Valset>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryValsetRequestRequest {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryValsetRequestResponse {
     #[prost(message, optional, tag="1")]
     pub valset: ::core::option::Option<Valset>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryValsetConfirmRequest {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
     #[prost(string, tag="2")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryValsetConfirmResponse {
     #[prost(message, optional, tag="1")]
     pub confirm: ::core::option::Option<MsgValsetConfirm>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryValsetConfirmsByNonceRequest {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryValsetConfirmsByNonceResponse {
     #[prost(message, repeated, tag="1")]
     pub confirms: ::prost::alloc::vec::Vec<MsgValsetConfirm>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastValsetRequestsRequest {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastValsetRequestsResponse {
     #[prost(message, repeated, tag="1")]
     pub valsets: ::prost::alloc::vec::Vec<Valset>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastPendingValsetRequestByAddrRequest {
     #[prost(string, tag="1")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastPendingValsetRequestByAddrResponse {
     #[prost(message, repeated, tag="1")]
     pub valsets: ::prost::alloc::vec::Vec<Valset>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryBatchFeeRequest {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryBatchFeeResponse {
     #[prost(message, repeated, tag="1")]
     pub batch_fees: ::prost::alloc::vec::Vec<BatchFees>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastPendingBatchRequestByAddrRequest {
     #[prost(string, tag="1")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastPendingBatchRequestByAddrResponse {
     #[prost(message, repeated, tag="1")]
     pub batch: ::prost::alloc::vec::Vec<OutgoingTxBatch>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastPendingLogicCallByAddrRequest {
     #[prost(string, tag="1")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastPendingLogicCallByAddrResponse {
     #[prost(message, repeated, tag="1")]
     pub call: ::prost::alloc::vec::Vec<OutgoingLogicCall>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryOutgoingTxBatchesRequest {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryOutgoingTxBatchesResponse {
     #[prost(message, repeated, tag="1")]
     pub batches: ::prost::alloc::vec::Vec<OutgoingTxBatch>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryOutgoingLogicCallsRequest {
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryOutgoingLogicCallsResponse {
     #[prost(message, repeated, tag="1")]
     pub calls: ::prost::alloc::vec::Vec<OutgoingLogicCall>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryBatchRequestByNonceRequest {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
     #[prost(string, tag="2")]
     pub contract_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryBatchRequestByNonceResponse {
     #[prost(message, optional, tag="1")]
     pub batch: ::core::option::Option<OutgoingTxBatch>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryBatchConfirmsRequest {
     #[prost(uint64, tag="1")]
     pub nonce: u64,
     #[prost(string, tag="2")]
     pub contract_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryBatchConfirmsResponse {
     #[prost(message, repeated, tag="1")]
     pub confirms: ::prost::alloc::vec::Vec<MsgConfirmBatch>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLogicConfirmsRequest {
     #[prost(bytes="vec", tag="1")]
     pub invalidation_id: ::prost::alloc::vec::Vec<u8>,
     #[prost(uint64, tag="2")]
     pub invalidation_nonce: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLogicConfirmsResponse {
     #[prost(message, repeated, tag="1")]
     pub confirms: ::prost::alloc::vec::Vec<MsgConfirmLogicCall>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastEventNonceByAddrRequest {
     #[prost(string, tag="1")]
     pub address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryLastEventNonceByAddrResponse {
     #[prost(uint64, tag="1")]
     pub event_nonce: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryErc20ToDenomRequest {
     #[prost(string, tag="1")]
     pub erc20: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryErc20ToDenomResponse {
     #[prost(string, tag="1")]
     pub denom: ::prost::alloc::string::String,
     #[prost(bool, tag="2")]
     pub cosmos_originated: bool,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDenomToErc20Request {
     #[prost(string, tag="1")]
     pub denom: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDenomToErc20Response {
     #[prost(string, tag="1")]
     pub erc20: ::prost::alloc::string::String,
@@ -1476,7 +1476,7 @@ pub struct QueryDenomToErc20Response {
 /// Filtering criteria may also be provided, including nonce, claim type, and
 /// height. Note, that an attestation will be returned if it matches ANY of the
 /// filter query parameters provided.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryAttestationsRequest {
     /// limit defines how many attestations to limit in the response.
     #[prost(uint64, tag="1")]
@@ -1501,55 +1501,55 @@ pub struct QueryAttestationsResponse {
     #[prost(message, repeated, tag="1")]
     pub attestations: ::prost::alloc::vec::Vec<Attestation>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDelegateKeysByValidatorAddress {
     #[prost(string, tag="1")]
     pub validator_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDelegateKeysByValidatorAddressResponse {
     #[prost(string, tag="1")]
     pub eth_address: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub orchestrator_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDelegateKeysByEthAddress {
     #[prost(string, tag="1")]
     pub eth_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDelegateKeysByEthAddressResponse {
     #[prost(string, tag="1")]
     pub validator_address: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub orchestrator_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDelegateKeysByOrchestratorAddress {
     #[prost(string, tag="1")]
     pub orchestrator_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryDelegateKeysByOrchestratorAddressResponse {
     #[prost(string, tag="1")]
     pub validator_address: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub eth_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryPendingSendToEth {
     #[prost(string, tag="1")]
     pub sender_address: ::prost::alloc::string::String,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryPendingSendToEthResponse {
     #[prost(message, repeated, tag="1")]
     pub transfers_in_batches: ::prost::alloc::vec::Vec<OutgoingTransferTx>,
     #[prost(message, repeated, tag="2")]
     pub unbatched_transfers: ::prost::alloc::vec::Vec<OutgoingTransferTx>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, ::prost::Message)]
 pub struct QueryPendingIbcAutoForwards {
     /// limit defines the number of pending forwards to return, in order of their SendToCosmos.EventNonce
     #[prost(uint64, tag="1")]

--- a/orchestrator/gravity_utils/src/types/config.rs
+++ b/orchestrator/gravity_utils/src/types/config.rs
@@ -171,7 +171,7 @@ pub enum BatchRequestMode {
 
 /// A whitelisted token that will be relayed given the batch
 /// provides at least amount of this specific token
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct WhitelistToken {
     /// the price of this token, denominated in weth per coin
     pub price: Uint256,

--- a/orchestrator/gravity_utils/src/types/ethereum_events.rs
+++ b/orchestrator/gravity_utils/src/types/ethereum_events.rs
@@ -244,6 +244,15 @@ impl ValsetUpdatedEvent {
         }
         ret
     }
+    // gets the Ethereum block for the given nonce
+    pub fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
+        for item in input {
+            if item.event_nonce == event_nonce {
+                return Some(item.block_height.clone());
+            }
+        }
+        None
+    }
 }
 
 /// A parsed struct representing the Ethereum event fired by the Gravity contract when
@@ -326,6 +335,16 @@ impl TransactionBatchExecutedEvent {
             }
         }
         ret
+    }
+
+    // gets the Ethereum block for the given nonce
+    pub fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
+        for item in input {
+            if item.event_nonce == event_nonce {
+                return Some(item.block_height.clone());
+            }
+        }
+        None
     }
 }
 
@@ -503,6 +522,16 @@ impl SendToCosmosEvent {
             }
         }
         ret
+    }
+
+    // gets the Ethereum block for the given nonce
+    pub fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
+        for item in input {
+            if item.event_nonce == event_nonce {
+                return Some(item.block_height.clone());
+            }
+        }
+        None
     }
 }
 
@@ -789,6 +818,16 @@ impl Erc20DeployedEvent {
         }
         ret
     }
+
+    // gets the Ethereum block for the given nonce
+    pub fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
+        for item in input {
+            if item.event_nonce == event_nonce {
+                return Some(item.block_height.clone());
+            }
+        }
+        None
+    }
 }
 /// A parsed struct representing the Ethereum event fired when someone uses the Gravity
 /// contract to deploy a new ERC20 contract representing a Cosmos asset
@@ -822,6 +861,16 @@ impl LogicCallExecutedEvent {
             }
         }
         ret
+    }
+
+    // gets the Ethereum block for the given nonce
+    pub fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
+        for item in input {
+            if item.event_nonce == event_nonce {
+                return Some(item.block_height.clone());
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
As an optimization strategy the orchestrator bundles as many oracle
submissions as possible into a single message. Normally this works
great but recently a validator that has not been active for some time
unajailed nad has found their orchestrator unable to catch up because it
can not submit the thousands of events as a single message.

This patch adds a constant cap to the number of oracle events in a
single transaction which would prevent this scenario. I'm not totally happy with this patch as the event processing code is badly in need of some generics. Last time I tried this the traits proved to be too frustrating to untangle but I know it can be done better. 

Fixes #188 