### PR TITLE
Add blank erc20 test

### DIFF
--- a/orchestrator/test_runner/src/invalid_events.rs
+++ b/orchestrator/test_runner/src/invalid_events.rs
@@ -186,6 +186,14 @@ fn get_erc20_test_values() -> Vec<Erc20Params> {
         decimals: 255,
     });
 
+    let blank = String::new().as_bytes().to_vec();
+    test_strings.push(Erc20Params {
+        erc20_symbol: blank.clone(),
+        erc20_name: blank.clone(),
+        cosmos_denom: blank,
+        decimals: 6,
+    });
+
     // move into testing long but valid utf8
     // a very long, but valid utf8 string
     let rand_string: String = thread_rng()


### PR DESCRIPTION
This patch expands the test cases for ERC20 deployments to include a
intentionally blank ERC20 contract.