### PR TITLE
WIP: Check batch equivalency

### DIFF
--- a/module/x/gravity/migrations/v3/store_test.go
+++ b/module/x/gravity/migrations/v3/store_test.go
@@ -64,7 +64,8 @@ func TestMigrateAttestation(t *testing.T) {
 	require.NoError(t, err)
 	attestationOldKey := v2.GetAttestationKey(nonce, oldClaimHash)
 
-	store.Set(attestationOldKey, marshaler.MustMarshal(dummyAttestation))
+	msgBytes := marshaler.MustMarshal(dummyAttestation)
+	store.Set(attestationOldKey, msgBytes)
 
 	// Run migrations
 	err = MigrateStore(ctx, gravityKey, marshaler)
@@ -75,6 +76,7 @@ func TestMigrateAttestation(t *testing.T) {
 	// Check migration results:
 	require.Empty(t, oldKeyEntry)
 	require.NotEqual(t, oldKeyEntry, newKeyEntry)
+	require.Equal(t, newKeyEntry, msgBytes)
 	require.NotEqual(t, newKeyEntry, []byte(""))
 	require.NotEmpty(t, newKeyEntry)
 }


### PR DESCRIPTION
This is a pr purely for the purpose of checking that migrated batches are exactly equal to their pre-migration counterparts which is generally missing from the testing infra right now becuase we're using a get/set pattern where we individually test the getter and setters with existing tests. 