### PR TITLE
Remove merge countdown, modify block delay

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1192,7 +1192,7 @@ dependencies = [
 
 [[package]]
 name = "gbt"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "actix-rt",
  "clap",

--- a/orchestrator/gbt/Cargo.toml
+++ b/orchestrator/gbt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbt"
-version = "1.7.0"
+version = "1.7.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -36,14 +36,6 @@ use tokio::time::sleep as delay_for;
 use tonic::transport::Channel;
 use web30::client::Web3;
 
-/// The total terminal difficulty for "The Merge" where Ethereum becomes PoS
-pub const ETH_MERGE_TTD: u128 = 58750000000000000000000u128;
-/// Computed to be about 48 hours before the merge, at this height we will pause
-/// the Gravity oracle
-pub const ETH_GRAV_HALT_TTD: u128 = 58591842390178918929502u128;
-/// An the approximate change to TDD in an hour as computed Sep 4
-/// 100% garunteed to be somewhat inaccurate
-pub const APPROX_TDD_PER_HOUR: f64 = 3294950204605855635.0;
 /// The execution speed governing all loops in this file
 /// which is to say all loops started by Orchestrator main
 /// loop except the relayer loop
@@ -118,8 +110,6 @@ pub async fn eth_oracle_main_loop(
     gravity_contract_address: EthAddress,
     fee: Coin,
 ) {
-    let merge_terminal_total_difficulty: Uint256 = ETH_MERGE_TTD.into();
-    let grav_oracle_halt_total_difficulty: Uint256 = ETH_GRAV_HALT_TTD.into();
     let our_cosmos_address = cosmos_key.to_address(&contact.get_prefix()).unwrap();
     let long_timeout_web30 = Web3::new(&web3.get_url(), Duration::from_secs(120));
     let block_delay = get_block_delay(&web3).await;
@@ -188,39 +178,6 @@ pub async fn eth_oracle_main_loop(
                 delay_for(DELAY).await;
                 continue;
             }
-        }
-
-        let latest_concise_block = web3
-            .eth_get_block_by_number(latest_eth_block.unwrap())
-            .await;
-        if let Ok(block) = latest_concise_block {
-            if block.total_difficulty >= grav_oracle_halt_total_difficulty {
-                info!("Total difficulty {}", block.total_difficulty);
-                // print some nice progress messages for users
-                if merge_terminal_total_difficulty >= block.total_difficulty {
-                    let estimated_remaining_difficulty =
-                        merge_terminal_total_difficulty.clone() - block.total_difficulty.clone();
-                    let estimated_remaining_difficulty: f64 =
-                        estimated_remaining_difficulty.to_string().parse().unwrap();
-                    let estimated_hours = estimated_remaining_difficulty / APPROX_TDD_PER_HOUR;
-
-                    info!("Orchestrator has detected ETH2 merge will occur within 48 hours oracle is now halted");
-                    info!(
-                        "Current TDD {} ETH2 Merge {} Estimated {:.2} hours until the merge",
-                        block.total_difficulty, ETH_MERGE_TTD, estimated_hours
-                    );
-                } else {
-                    info!("ETH2 Merge Complete! Please see Discord and Chain Governance for next steps to re-enable the bridge post merge!")
-                }
-
-                delay_for(ETH_ORACLE_WAITING_SPEED).await;
-                continue;
-            }
-        } else {
-            warn!("Unable to check terminal difficulty, not running oracle");
-
-            delay_for(ETH_ORACLE_WAITING_SPEED).await;
-            continue;
         }
 
         // if the governance vote reset last event nonce sent by validator to some lower value, we can detect this


### PR DESCRIPTION
This patch *is not* a complete ethereum proof of stake update for the Orchestrator. It only removes the merge countdown and sets a 64 block delay for assumed finality.

Previously we waited 13 blocks for finality given known probabilities of proof of work re-orgs but there was no way to really 'know' when somthing was final.

ETH2 does provide actual finality. The problem is it takes a while and is difficult to query. Mapping consensus layer slots to execution layer blocks is a complex process best left to an API query which does not seem to exist, at least in any obvious form.

This patch uses a 64 block delay which is in all probability safer than our previous proof of work delay, but does not check for actual ETH2 finality, we will update GBT to do this in the future once we have a 100% reliable way to map slots/epochs to execution layer blocks.

We could attempt a hardcoded offset mapping, but in the case where many slots pass with no block block delay finality is safer than using a hardcoded offset to map execution layer blocks to slots since empty slots will shrink the rolling window and silently reduce saftey whereas a block delay at the execution layer becomes more likley to be finlaized if slots are missed at the consensus layer.