### PR TITLE
Fix automated upgrade test

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -69,6 +69,17 @@ jobs:
           asset_name: gbt
           asset_content_type: application/bin
 
+      - name: Upload Gravity Bridge test runner
+        id: upload-test-runner
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./orchestrator/target/x86_64-unknown-linux-musl/release/test-runner
+          asset_name: test-runner
+          asset_content_type: application/bin
+
       - name: Upload Gravity Bridge Build Report
         id: upload-gravity-bridge-build-report
         uses: actions/upload-release-asset@v1

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -15,5 +15,9 @@ set +e
 killall -9 test-runner
 set -e
 
+if [[ ! -z ${OLD_TESTRUNNER_LOCATION} ]]; then
+    RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO ./OLD_TESTRUNNER_LOCATION
+else
 pushd /gravity/orchestrator/test_runner
 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner
+fi

--- a/tests/container-scripts/upgrade-test-internal.sh
+++ b/tests/container-scripts/upgrade-test-internal.sh
@@ -6,12 +6,13 @@ NODES=$1
 OLD_VERSION=$2
 
 echo "Downloading old gravity version at https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/${OLD_VERSION}/gravity-linux-amd64"
-wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/${OLD_VERSION}/gravity-linux-amd64
-mv gravity-linux-amd64 oldgravity
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/${OLD_VERSION}/gravity-linux-amd64 -O oldgravity
+wget https://github.com/Gravity-Bridge/Gravity-Bridge/releases/download/${OLD_VERSION}/test-runner -O oldtestrunner
 # Make old gravity executable
 chmod +x oldgravity
 
 export OLD_BINARY_LOCATION=/oldgravity
+export OLD_TESTRUNNER_LOCATION=/oldtestrunner
 
 # Prepare the contracts for later deployment
 pushd /gravity/solidity/
@@ -40,6 +41,7 @@ tests/container-scripts/integration-tests.sh $NODES UPGRADE_PART_1
 popd
 
 unset OLD_BINARY_LOCATION
+unset OLD_TESTRUNNER_LOCATION
 # Run the new binary
 pkill gravity || true # allowed to fail
 tests/container-scripts/run-testnet.sh $NODES


### PR DESCRIPTION
This fixes the automated upgrade test by downloading the test_runner binary itself to run the upgrade test v1 from that release. This does add the unexpected complexity of running the old version of part 1 of the test, which might not line up with the new part 2. But it does get things running.

In the long term the best solution to this problem is to break the test runner into a library so that it can be imported as a rust dependency.