### PR TITLE
Add MaxRate check to MinCommissionDecorator, Remove errant transfer module balance checks in Invariant

### DIFF
--- a/module/app/ante/min_commission.go
+++ b/module/app/ante/min_commission.go
@@ -35,6 +35,9 @@ func (min MinCommissionDecorator) AnteHandle(
 			if c.Rate.LT(minCommissionRate) {
 				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "commission can't be lower than 10%")
 			}
+			if c.MaxRate.LT(minCommissionRate) {
+				return sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "commission max rate can't be lower than 10%")
+			}
 		case *stakingtypes.MsgEditValidator:
 			// if commission rate is nil, it means only
 			// other fields are affected - skip


### PR DESCRIPTION
**MaxRate check:** While this check should be redundant due to upstream ValidateBasic checks, it is worth checking assumptions in the AnteHandler so that strange behavior is caught early

**Transfer module balance":** A mistake was made when writing the PendingIbcAutoForward invariant checks, the transfer module does not get custody of funds until the pending IBC Auto forward is executed, so the invariant is unable to make any claims about balances here. Adding a check to the gravity account's balance would inevitably cause an unnecessary chain halt.