### PR TITLE
Consistently generate build tags on Make 4.3+

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -39,7 +39,7 @@ build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
 whitespace :=
-whitespace += $(whitespace)
+whitespace := $(whitespace) $(whitespace)
 comma := ,
 build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
 


### PR DESCRIPTION
With Make 4.3+, the empty whitespace does not seem to work as originally intended. This causes build tags to be `"netgo ledger,"` on Ubuntu 22.04 and other systems that include the newer Make version. The build tags were intended as `"netgo,ledger"` which can be observed on Make 4.2 (shipped with Ubuntu 20.04).

This change swaps out the `+=` use in favor of an explicit `:=`.
Ref: https://www.gnu.org/software/make/manual/html_node/Appending.html

Upstream reference: cosmos/gaia#2017

This can be observed either via API or directly via CLI:

```text
$ gravityd version --long 2>&1 | head -n5
name: gravity
server_name: gravity
version: v1.8.1
commit: ea35ec51aa921f60bb0911bd5482f12a438241e0
build_tags: netgo ledger,
```