### PR TITLE
Fix logic call ClaimHash, add ClaimHash tests

### DIFF
--- a/module/x/gravity/types/msgs.go
+++ b/module/x/gravity/types/msgs.go
@@ -320,6 +320,8 @@ type EthereumClaim interface {
 	// validators claims agree. Therefore it's extremely important that this include all elements of the claim
 	// with the exception of the orchestrator who sent it in, which will be used as a different part of the index
 	ClaimHash() ([]byte, error)
+	// Sets the orchestrator value on the claim
+	SetOrchestrator(sdk.AccAddress)
 }
 
 // nolint: exhaustruct
@@ -329,6 +331,10 @@ var (
 	_ EthereumClaim = &MsgERC20DeployedClaim{}
 	_ EthereumClaim = &MsgLogicCallExecutedClaim{}
 )
+
+func (msg *MsgSendToCosmosClaim) SetOrchestrator(orchestrator sdk.AccAddress) {
+	msg.Orchestrator = orchestrator.String()
+}
 
 // GetType returns the type of the claim
 func (msg *MsgSendToCosmosClaim) GetType() ClaimType {
@@ -425,6 +431,10 @@ func (msg *MsgExecuteIbcAutoForwards) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{acc}
 }
 
+func (msg *MsgBatchSendToEthClaim) SetOrchestrator(orchestrator sdk.AccAddress) {
+	msg.Orchestrator = orchestrator.String()
+}
+
 // GetType returns the claim type
 func (msg *MsgBatchSendToEthClaim) GetType() ClaimType {
 	return CLAIM_TYPE_BATCH_SEND_TO_ETH
@@ -490,6 +500,10 @@ const (
 // EthereumClaim implementation for MsgERC20DeployedClaim
 // ======================================================
 
+func (msg *MsgERC20DeployedClaim) SetOrchestrator(orchestrator sdk.AccAddress) {
+	msg.Orchestrator = orchestrator.String()
+}
+
 // GetType returns the type of the claim
 func (e *MsgERC20DeployedClaim) GetType() ClaimType {
 	return CLAIM_TYPE_ERC20_DEPLOYED
@@ -553,6 +567,10 @@ func (b *MsgERC20DeployedClaim) ClaimHash() ([]byte, error) {
 // EthereumClaim implementation for MsgLogicCallExecutedClaim
 // ======================================================
 
+func (msg *MsgLogicCallExecutedClaim) SetOrchestrator(orchestrator sdk.AccAddress) {
+	msg.Orchestrator = orchestrator.String()
+}
+
 // GetType returns the type of the claim
 func (e *MsgLogicCallExecutedClaim) GetType() ClaimType {
 	return CLAIM_TYPE_LOGIC_CALL_EXECUTED
@@ -606,12 +624,15 @@ func (msg MsgLogicCallExecutedClaim) Route() string { return RouterKey }
 // note that the Orchestrator is the only field excluded from this hash, this is because that value is used higher up in the store
 // structure for who has made what claim and is verified by the msg ante-handler for signatures
 func (b *MsgLogicCallExecutedClaim) ClaimHash() ([]byte, error) {
-	path := fmt.Sprintf("%d,%d,%s/%d/", b.EventNonce, b.EthBlockHeight, b.InvalidationId, b.InvalidationNonce)
+	path := fmt.Sprintf("%d/%d/%s/%d", b.EventNonce, b.EthBlockHeight, b.InvalidationId, b.InvalidationNonce)
 	return tmhash.Sum([]byte(path)), nil
 }
 
 // EthereumClaim implementation for MsgValsetUpdatedClaim
 // ======================================================
+func (e *MsgValsetUpdatedClaim) SetOrchestrator(orchestrator sdk.AccAddress) {
+	e.Orchestrator = orchestrator.String()
+}
 
 // GetType returns the type of the claim
 func (e *MsgValsetUpdatedClaim) GetType() ClaimType {

--- a/module/x/gravity/types/msgs_test.go
+++ b/module/x/gravity/types/msgs_test.go
@@ -7,6 +7,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 )
 
 func TestValidateMsgSetOrchestratorAddress(t *testing.T) {
@@ -65,4 +67,172 @@ func TestValidateMsgSetOrchestratorAddress(t *testing.T) {
 		})
 	}
 
+}
+
+// Gets the ClaimHash() output from every claims member and casts it to a string, panicing on any errors
+func getClaimHashStrings(t *testing.T, claims ...EthereumClaim) (hashes []string) {
+	for _, claim := range claims {
+		hash, e := claim.ClaimHash()
+		require.NoError(t, e)
+		hashes = append(hashes, string(hash))
+	}
+	return
+}
+
+// Calls SetOrchestrator on every claims member, passing orch as the value
+func setOrchestratorOnClaims(orch sdk.AccAddress, claims ...EthereumClaim) (ret []EthereumClaim) {
+	for _, claim := range claims {
+		clam := claim
+		clam.SetOrchestrator(orch)
+		ret = append(ret, clam)
+	}
+	return
+}
+
+// Ensures that ClaimHash changes when members of MsgSendToCosmosClaim change
+// The only field which MUST NOT affect ClaimHash is Orchestrator
+func TestMsgSendToCosmosClaimHash(t *testing.T) {
+	base := MsgSendToCosmosClaim{
+		EventNonce:     0,
+		EthBlockHeight: 0,
+		TokenContract:  "",
+		Amount:         sdk.Int{},
+		EthereumSender: "",
+		CosmosReceiver: "",
+		Orchestrator:   "",
+	}
+
+	// Copy and populate base with values, saving orchestrator for a special check
+	orchestrator := NonemptySdkAccAddress()
+	mNonce := base
+	mNonce.EventNonce = NonzeroUint64()
+	mBlock := base
+	mBlock.EthBlockHeight = NonzeroUint64()
+	mCtr := base
+	mCtr.TokenContract = NonemptyEthAddress()
+	mAmt := base
+	mAmt.Amount = NonzeroSdkInt()
+	mSend := base
+	mSend.EthereumSender = NonemptyEthAddress()
+	mRecv := base
+	mRecv.CosmosReceiver = NonemptySdkAccAddress().String()
+
+	hashes := getClaimHashStrings(t, &base, &mNonce, &mBlock, &mCtr, &mAmt, &mSend, &mRecv)
+	baseH := hashes[0]
+	rest := hashes[1:]
+	// Assert that the base claim hash differs from all the rest
+	require.False(t, slices.Contains(rest, baseH))
+
+	newClaims := setOrchestratorOnClaims(orchestrator, &base, &mNonce, &mBlock, &mCtr, &mAmt, &mSend, &mRecv)
+	newHashes := getClaimHashStrings(t, newClaims...)
+	// Assert that the claims with orchestrator set do not change the hashes
+	require.Equal(t, hashes, newHashes)
+}
+
+// Ensures that ClaimHash changes when members of MsgBatchSendToEth change
+// The only field which MUST NOT affect ClaimHash is Orchestrator
+func TestMsgBatchSendToEthClaimHash(t *testing.T) {
+	base := MsgBatchSendToEthClaim{
+		EventNonce:     0,
+		EthBlockHeight: 0,
+		BatchNonce:     0,
+		TokenContract:  "",
+		Orchestrator:   "",
+	}
+
+	orchestrator := NonemptySdkAccAddress()
+	mNonce := base
+	mNonce.EventNonce = NonzeroUint64()
+	mBlock := base
+	mBlock.EthBlockHeight = NonzeroUint64()
+	mBatch := base
+	mBatch.BatchNonce = NonzeroUint64()
+	mCtr := base
+	mCtr.TokenContract = NonemptyEthAddress()
+
+	hashes := getClaimHashStrings(t, &base, &mNonce, &mBlock, &mBatch, &mCtr)
+	baseH := hashes[0]
+	rest := hashes[1:]
+	// Assert that the base claim hash differs from all the rest
+	require.False(t, slices.Contains(rest, baseH))
+
+	newClaims := setOrchestratorOnClaims(orchestrator, &base, &mNonce, &mBlock, &mBatch, &mCtr)
+	newHashes := getClaimHashStrings(t, newClaims...)
+	// Assert that the claims with orchestrator set do not change the hashes
+	require.Equal(t, hashes, newHashes)
+}
+
+// Ensures that ClaimHash changes when members of MsgERC20DeployedClaim change
+// The only field which MUST NOT affect ClaimHash is Orchestrator
+func TestMsgERC20DeployedClaimHash(t *testing.T) {
+	base := MsgERC20DeployedClaim{
+		EventNonce:     0,
+		EthBlockHeight: 0,
+		CosmosDenom:    "",
+		TokenContract:  "",
+		Name:           "",
+		Symbol:         "",
+		Decimals:       0,
+		Orchestrator:   "",
+	}
+
+	orchestrator := NonemptySdkAccAddress()
+	mNonce := base
+	mNonce.EventNonce = NonzeroUint64()
+	mBlock := base
+	mBlock.EthBlockHeight = NonzeroUint64()
+	mDenom := base
+	mDenom.CosmosDenom = NonemptyEthAddress()
+	mCtr := base
+	mCtr.TokenContract = NonemptyEthAddress()
+	mName := base
+	mName.Name = NonemptyEthAddress()
+	mSymb := base
+	mSymb.Symbol = NonemptyEthAddress()
+	mDecim := base
+	mDecim.Decimals = NonzeroUint64()
+
+	hashes := getClaimHashStrings(t, &base, &mNonce, &mBlock, &mDenom, &mName, &mSymb, &mDecim)
+	baseH := hashes[0]
+	rest := hashes[1:]
+	// Assert that the base claim hash differs from all the rest
+	require.False(t, slices.Contains(rest, baseH))
+
+	newClaims := setOrchestratorOnClaims(orchestrator, &base, &mNonce, &mBlock, &mDenom, &mName, &mSymb, &mDecim)
+	newHashes := getClaimHashStrings(t, newClaims...)
+	// Assert that the claims with orchestrator set do not change the hashes
+	require.Equal(t, hashes, newHashes)
+}
+
+// Ensures that ClaimHash changes when members of MsgLogicCallExecutedClaim change
+// The only field which MUST NOT affect ClaimHash is Orchestrator
+func TestMsgLogicCallExecutedClaimHash(t *testing.T) {
+	base := MsgLogicCallExecutedClaim{
+		EventNonce:        0,
+		EthBlockHeight:    0,
+		InvalidationId:    []byte{},
+		InvalidationNonce: 0,
+		Orchestrator:      "",
+	}
+
+	orchestrator := NonemptySdkAccAddress()
+	mNonce := base
+	mNonce.EventNonce = NonzeroUint64()
+	mBlock := base
+	mBlock.EthBlockHeight = NonzeroUint64()
+	mInvId := base
+	mInvId.InvalidationId = NonemptySdkAccAddress().Bytes()
+	mInvNo := base
+	mInvNo.InvalidationNonce = NonzeroUint64()
+
+	hashes := getClaimHashStrings(t, &base, &mNonce, &mBlock, &mInvId, &mInvNo)
+	baseH := hashes[0]
+	rest := hashes[1:]
+	// Assert that the base claim hash differs from all the rest
+	require.False(t, slices.Contains(rest, baseH))
+
+	newClaims := setOrchestratorOnClaims(orchestrator, &base, &mNonce, &mBlock, &mInvId, &mInvNo)
+	newHashes := getClaimHashStrings(t, newClaims...)
+	// Assert that the claims with orchestrator set do not change the hashes
+	require.Equal(t, hashes, newHashes)
 }

--- a/module/x/gravity/types/test_utils.go
+++ b/module/x/gravity/types/test_utils.go
@@ -1,0 +1,50 @@
+package types
+
+import (
+	"encoding/hex"
+	"math/big"
+	"math/rand"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Creates a random nonzero uint64 test value
+func NonzeroUint64() (ret uint64) {
+	for ret == 0 {
+		ret = rand.Uint64()
+	}
+	return
+}
+
+// Creates a random nonempty 20 byte sdk.AccAddress string test value
+func NonemptySdkAccAddress() (ret sdk.AccAddress) {
+	for ret.Empty() {
+		addr := make([]byte, 20)
+		rand.Read(addr)
+		ret = sdk.AccAddress(addr)
+	}
+	return
+}
+
+// Creates a random nonempty 20 byte address hex string test value
+func NonemptyEthAddress() (ret string) {
+	for ret == "" {
+		addr := make([]byte, 20)
+		rand.Read(addr)
+		ret = hex.EncodeToString(addr)
+	}
+	ret = "0x" + ret
+	return
+}
+
+// Creates a random nonzero sdk.Int test value
+func NonzeroSdkInt() (ret sdk.Int) {
+	amount := big.NewInt(0)
+	for amount.Cmp(big.NewInt(0)) == 0 {
+		amountBz := make([]byte, 32)
+		rand.Read(amountBz)
+		amount = big.NewInt(0).SetBytes(amountBz)
+	}
+	ret = sdk.NewIntFromBigInt(amount)
+	return
+}


### PR DESCRIPTION
The SetOrchestrator method was added to EthereumClaim to make testing MUCH easier, reduces a lot of testing bloat this way.