### PR TITLE
2. Update orchestrator to use Cargo workspace dependencies, update for num256 bnum implementation

### DIFF
--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "actix_derive",
  "bitflags",
  "bytes",
- "crossbeam-channel 0.5.6",
+ "crossbeam-channel 0.5.7",
  "futures-core",
  "futures-sink",
  "futures-task",
@@ -45,15 +45,15 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0070905b2c4a98d184c4e81025253cb192aa8a73827553f38e9410801ceb35bb"
+checksum = "c2079246596c18b4a33e274ae10c0e50613f4d32a4198e09c7b93771013fed74"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash",
+ "ahash 0.8.3",
  "base64 0.21.0",
  "bitflags",
  "bytes",
@@ -88,7 +88,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -150,7 +150,7 @@ checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -171,6 +171,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,10 +192,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.68"
+name = "althea_proto"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "44fc09d6122dabdc788fa875127fc04053f976aa771f63246eeb5634146ffc74"
+dependencies = [
+ "cosmos-sdk-proto-althea",
+ "prost 0.10.4",
+ "prost-types 0.10.1",
+ "tonic 0.7.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "arrayvec"
@@ -199,34 +223,35 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-stream"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -264,9 +289,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "awc"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dff3fc64a176e0d4398c71b0f2c2679ff4a723c6ed8fcc68dfe5baa00665388"
+checksum = "87ef547a81796eb2dfe9b345aba34c2e08391a0502493711395b36dd64052b69"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -274,7 +299,7 @@ dependencies = [
  "actix-service",
  "actix-tls",
  "actix-utils",
- "ahash",
+ "ahash 0.7.6",
  "base64 0.21.0",
  "bytes",
  "cfg-if 1.0.0",
@@ -327,12 +352,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.4"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
+checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
 dependencies = [
  "async-trait",
- "axum-core 0.3.2",
+ "axum-core 0.3.3",
  "bitflags",
  "bytes",
  "futures-util",
@@ -349,7 +374,6 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -372,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cae3e661676ffbacb30f1a824089a8c9150e71017f7e1e38f2aa32009188d34"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -407,9 +431,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
@@ -455,56 +479,65 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
-name = "borsh"
-version = "0.9.3"
+name = "bnum"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+checksum = "29ed1ec45f6ef6e8d1125cc2c2fec8f8fe7d4fa5b262f15885fdccb9e26f0f15"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.9.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate",
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.9.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.9.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -515,23 +548,24 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -548,24 +582,24 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytestring"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f83e57d9154148e355404702e2694463241880b939570d7c97c014da7a69a1"
+checksum = "238e4886760d98c4f899360c834fa93e62cf7f721ac3c2da375cbdf4b8679aae"
 dependencies = [
  "bytes",
 ]
 
 [[package]]
 name = "camino"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -594,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -646,7 +680,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -660,17 +694,13 @@ dependencies = [
 
 [[package]]
 name = "clarity"
-version = "0.5.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4571596842d9326a73c215e81b36c7c6e110656ce7aa905cb4df495f138ff71"
+checksum = "2d492988d807e543bfb5c0b67f164e23371816b232219e1bc191bb864cdd2ff6"
 dependencies = [
- "byteorder",
- "lazy_static",
- "num",
- "num-bigint",
  "num-traits",
  "num256",
- "secp256k1 0.25.0",
+ "secp256k1 0.26.0",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -688,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "contracts"
@@ -700,7 +730,7 @@ checksum = "f1d1429e3bd78171c65aa010eabcdf8f863ba3254728dbfb0ad4b1545beac15c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -793,23 +823,23 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.15",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.15",
  "memoffset",
  "scopeguard",
 ]
@@ -827,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -886,18 +916,18 @@ dependencies = [
 
 [[package]]
 name = "deep_space"
-version = "2.15.2"
+version = "2.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea6098ba58f6a9a3fa9773120dc9dd2246af3574613ec7af2641e1e118c4b4f"
+checksum = "550445b69ad718bd2f575a17968ccb26a28de24499a900b62d2f6b7ddecda887"
 dependencies = [
- "base64 0.13.1",
+ "althea_proto",
+ "base64 0.21.0",
  "bech32",
  "bytes",
  "clarity",
  "cosmos-sdk-proto-althea",
  "hmac",
  "log",
- "num-bigint",
  "num-traits",
  "num256",
  "pbkdf2",
@@ -906,7 +936,7 @@ dependencies = [
  "rand",
  "ripemd",
  "rust_decimal",
- "secp256k1 0.24.3",
+ "secp256k1 0.26.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -937,7 +967,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -955,7 +985,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1048,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
@@ -1074,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1151,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -1235,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1250,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1260,15 +1290,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1277,38 +1307,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1405,6 +1435,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num-bigint",
+ "num-traits",
  "num256",
  "rand",
  "serde",
@@ -1429,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1454,20 +1485,20 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -1506,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1529,6 +1560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -1601,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1685,7 +1722,7 @@ dependencies = [
  "ics23",
  "num-traits",
  "primitive-types",
- "prost 0.11.6",
+ "prost 0.11.8",
  "safe-regex",
  "serde",
  "serde_derive",
@@ -1708,7 +1745,7 @@ checksum = "cf27ba26c12fa0e270a32f8e54a9d9768e19d0f2e6f36b83a1f274f7fa1c2755"
 dependencies = [
  "base64 0.13.1",
  "bytes",
- "prost 0.11.6",
+ "prost 0.11.8",
  "serde",
  "tendermint-proto",
  "tonic 0.8.3",
@@ -1725,7 +1762,7 @@ dependencies = [
  "bech32",
  "bitcoin",
  "bytes",
- "crossbeam-channel 0.5.6",
+ "crossbeam-channel 0.5.7",
  "dirs-next",
  "flex-error",
  "futures",
@@ -1741,7 +1778,7 @@ dependencies = [
  "moka",
  "num-bigint",
  "num-rational",
- "prost 0.11.6",
+ "prost 0.11.8",
  "regex",
  "retry",
  "ripemd",
@@ -1764,7 +1801,7 @@ dependencies = [
  "toml",
  "tonic 0.8.3",
  "tracing",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -1776,7 +1813,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "hex",
- "prost 0.11.6",
+ "prost 0.11.8",
  "ripemd",
  "sha2 0.10.6",
  "sha3",
@@ -1828,24 +1865,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1859,24 +1897,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1916,9 +1954,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1998,9 +2036,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2016,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2031,25 +2069,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "moka"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b49a05f67020456541f4f29cbaa812016a266a86ec76f96d3873d459c68fe5e"
+checksum = "19b9268097a2cf211ac9955b1cc95e80fa84fff5c2d13ba292916445dc8a311f"
 dependencies = [
- "crossbeam-channel 0.5.6",
+ "crossbeam-channel 0.5.7",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.15",
  "num_cpus",
  "once_cell",
  "parking_lot",
@@ -2061,7 +2099,7 @@ dependencies = [
  "tagptr",
  "thiserror",
  "triomphe",
- "uuid 1.2.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2113,7 +2151,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2161,16 +2199,13 @@ dependencies = [
 
 [[package]]
 name = "num256"
-version = "0.3.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9b5179e82f0867b23e0b9b822493821f9345561f271364f409c8e4a058367d"
+checksum = "27dd9df2c73f8724f4f6930882c127f042656bc84e6000fe9f6026bb43fe1a57"
 dependencies = [
- "lazy_static",
- "num",
- "num-derive",
+ "bnum",
  "num-traits",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -2194,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -2206,9 +2241,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2227,7 +2262,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2238,18 +2273,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.24.0+1.1.1s"
+version = "111.25.2+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
 dependencies = [
  "autocfg",
  "cc",
@@ -2276,6 +2311,7 @@ dependencies = [
  "lazy_static",
  "log",
  "metrics_exporter",
+ "num-traits",
  "num256",
  "openssl",
  "openssl-probe",
@@ -2291,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.1"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parking_lot"
@@ -2307,15 +2343,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2331,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pbkdf2"
@@ -2382,9 +2418,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2407,7 +2443,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2446,12 +2482,12 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2483,7 +2519,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -2500,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -2546,12 +2582,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
- "prost-derive 0.11.6",
+ "prost-derive 0.11.8",
 ]
 
 [[package]]
@@ -2586,20 +2622,20 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2614,12 +2650,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
- "prost 0.11.6",
+ "prost 0.11.8",
 ]
 
 [[package]]
@@ -2651,7 +2686,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2671,7 +2706,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e31331286705f455e56cca62e0e717158474ff02b7936c1fa596d983f4ae27"
 dependencies = [
- "crossbeam-utils 0.8.14",
+ "crossbeam-utils 0.8.15",
  "libc",
  "mach",
  "once_cell",
@@ -2683,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2728,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "10.6.0"
+version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags",
 ]
@@ -2757,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2768,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "relayer"
@@ -2799,19 +2834,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
@@ -2870,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -2884,20 +2910,20 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "rust_decimal"
-version = "1.28.0"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe32e8c89834541077a5c5bbe5691aa69324361e27e6aeb3552a737db4a70c8"
+checksum = "2b1b21b8760b0ef8ae5b43d40913ff711a2053cb7ff892a34facff7a6365375a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2928,16 +2954,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3000,15 +3026,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safe-proc-macro2"
@@ -3072,14 +3098,14 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
 ]
@@ -3143,11 +3169,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550fc3b723a478be77bf74718947cdcdd75144d508aaa70f0a320036905df2a8"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
 dependencies = [
- "secp256k1-sys 0.7.0",
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]
@@ -3161,18 +3187,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8058e28ae464daf5ac14c5c0f78110b58616e796c4e4e28cfcca38fdb13d8f22"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "security-framework"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3193,27 +3219,27 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -3230,20 +3256,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.8",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -3252,13 +3278,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -3331,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -3347,6 +3373,12 @@ dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "skeptic"
@@ -3365,9 +3397,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -3380,9 +3412,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3433,9 +3465,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3444,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -3456,7 +3499,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -3468,16 +3511,15 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3495,8 +3537,8 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost 0.11.6",
- "prost-types 0.11.6",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
  "ripemd160",
  "serde",
  "serde_bytes",
@@ -3570,8 +3612,8 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.11.6",
- "prost-types 0.11.6",
+ "prost 0.11.8",
+ "prost-types 0.11.8",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -3664,22 +3706,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -3752,15 +3794,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3773,7 +3815,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3794,7 +3836,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3833,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3844,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3909,7 +3951,7 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.4",
+ "axum 0.6.12",
  "base64 0.13.1",
  "bytes",
  "futures-core",
@@ -3921,8 +3963,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.6",
- "prost-derive 0.11.6",
+ "prost 0.11.8",
+ "prost-derive 0.11.8",
  "rustls-native-certs 0.6.2",
  "rustls-pemfile",
  "tokio",
@@ -3946,7 +3988,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4021,7 +4063,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4105,15 +4147,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -4161,9 +4203,9 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
 ]
@@ -4182,12 +4224,11 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
- "winapi",
  "winapi-util",
 ]
 
@@ -4215,9 +4256,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4225,24 +4266,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4250,28 +4291,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4279,16 +4320,16 @@ dependencies = [
 
 [[package]]
 name = "web30"
-version = "0.22.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5db33bc4a6465d2111c276858700924031c09d0fbf633d693189d88361d7a5"
+checksum = "4f5347fb90d290dee1f597b92a9a416b4f102906a11afd5ee674eddbb62beb0d"
 dependencies = [
  "awc",
  "clarity",
  "futures",
  "lazy_static",
  "log",
- "num",
+ "num-traits",
  "num256",
  "serde",
  "serde_derive",
@@ -4383,46 +4424,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "zeroize"
@@ -4441,24 +4506,24 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "synstructure",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.12.2+zstd.1.5.2"
+version = "0.12.3+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9262a83dc741c0b0ffec209881b45dbc232c21b02a2b9cb1adb93266e41303d"
+checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.2+zstd.1.5.2"
+version = "6.0.4+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
+checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4466,9 +4531,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.5+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
 dependencies = [
  "cc",
  "libc",

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -223,9 +223,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-stream"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -234,24 +234,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -709,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosmos-sdk-proto-althea"
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
 ]
@@ -1126,13 +1126,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1290,15 +1290,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1307,38 +1307,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1397,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -1846,9 +1846,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -1865,25 +1865,25 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1954,15 +1954,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "local-channel"
@@ -2241,9 +2241,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "4d2f106ab837a24e03672c59b1239669a0596406ff657c3c0835b6b7f0f35a33"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2256,13 +2256,13 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -2282,11 +2282,10 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "3a20eace9dc2d82904039cb76dcf50fb1a0bba071cfd1629720b5d6f1ddba0fa"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -2349,7 +2348,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -2536,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2780,21 +2779,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2896,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.40"
+version = "0.7.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
+checksum = "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -2910,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.40"
+version = "0.7.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
+checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2921,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.29.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1b21b8760b0ef8ae5b43d40913ff711a2053cb7ff892a34facff7a6365375a"
+checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2954,16 +2962,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "1aef160324be24d31a62147fae491c14d2204a3865c7ca8c3b0d7f7bcb3ea635"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3228,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
 dependencies = [
  "serde_derive",
 ]
@@ -3256,20 +3264,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
 dependencies = [
  "itoa",
  "ryu",
@@ -3284,7 +3292,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3476,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3492,18 +3500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,15 +3507,15 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3721,7 +3717,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -3800,14 +3796,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -3830,13 +3825,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4414,13 +4409,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4429,7 +4424,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4438,13 +4442,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4454,10 +4473,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4466,10 +4497,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4478,10 +4521,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4490,24 +4545,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
-name = "zeroize"
-version = "1.5.7"
+name = "windows_x86_64_msvc"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4521,9 +4581,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.4+zstd.1.5.4"
+version = "6.0.5+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7afb4b54b8910cf5447638cb54bf4e8a65cbedd783af98b98c62ffe91f185543"
+checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4531,9 +4591,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
+version = "2.0.8+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -1,3 +1,12 @@
 [workspace]
 members = ["orchestrator", "cosmos_gravity", "ethereum_gravity", "gravity_utils", "proto_build", "test_runner", "gravity_proto", "relayer", "gbt", "metrics_exporter"]
 default-members = ["gbt"]
+
+[workspace.dependencies]
+num256 = "0.5"
+clarity = "0.7"
+web30 = "0.23"
+deep_space = "2.17"
+prost = "0.10"
+prost-types = "0.10"
+tonic = "0.7"

--- a/orchestrator/cosmos_gravity/Cargo.toml
+++ b/orchestrator/cosmos_gravity/Cargo.toml
@@ -11,20 +11,20 @@ gravity_utils = {path = "../gravity_utils"}
 ethereum_gravity = {path = "../ethereum_gravity"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "2.15"
-clarity = "0.5"
+deep_space = {workspace = true}
+clarity = {workspace = true}
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-num256 = "0.3"
+num256 = {workspace = true}
 log = "0.4"
 sha3 = "0.10"
 tokio = "1.4"
-web30 = "0.22"
-tonic = "0.7"
+web30 = {workspace = true}
+tonic = {workspace = true}
 bytes = "1.1"
-prost-types = "0.10"
-prost = "0.10"
+prost-types = {workspace = true}
+prost = {workspace = true}
 num = "0.4.0"
 
 [dev-dependencies]

--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -320,7 +320,7 @@ pub async fn send_to_eth(
     let chain_fee = match chain_fee {
         Some(fee) => fee,
         None => Coin {
-            amount: get_reasonable_send_to_eth_fee(contact, amount.amount.clone())
+            amount: get_reasonable_send_to_eth_fee(contact, amount.amount)
                 .await
                 .expect("Unable to get reasonable SendToEth fee"),
             denom: amount.denom.clone(),
@@ -336,7 +336,7 @@ pub async fn send_to_eth(
     let mut found = false;
     for balance in balances {
         if balance.denom == amount.denom {
-            let total_amount = amount.amount.clone() + (fee.amount.clone() * 2u8.into());
+            let total_amount = amount.amount + (fee.amount * 2u8.into());
             if balance.amount < total_amount {
                 return Err(CosmosGrpcError::BadInput(format!(
                     "Insufficient balance of {} to send {}",

--- a/orchestrator/cosmos_gravity/src/utils.rs
+++ b/orchestrator/cosmos_gravity/src/utils.rs
@@ -11,7 +11,6 @@ use gravity_utils::get_with_retry::RETRY_TIME;
 use gravity_utils::types::LogicCall;
 use gravity_utils::types::TransactionBatch;
 use gravity_utils::types::Valset;
-use num::Integer;
 use num256::Uint256;
 use prost_types::Any;
 use std::convert::TryFrom;
@@ -109,7 +108,7 @@ pub async fn get_reasonable_send_to_eth_fee(
 pub fn get_min_send_to_eth_fee(bridge_amount: Uint256, min_fee_basis_points: Uint256) -> Uint256 {
     Uint256(
         bridge_amount
-            .div_ceil(&Uint256::from(BASIS_POINT_DIVISOR).0)
+            .div_ceil(Uint256::from(BASIS_POINT_DIVISOR).0)
             .mul(min_fee_basis_points.0),
     )
 }

--- a/orchestrator/ethereum_gravity/Cargo.toml
+++ b/orchestrator/ethereum_gravity/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 [dependencies]
 gravity_utils = {path = "../gravity_utils"}
 
-deep_space = "2.15"
-clarity = "0.5"
-web30 = "0.22"
-num256 = "0.3"
+deep_space = {workspace = true}
+clarity = {workspace = true}
+web30 = {workspace = true}
+num256 = {workspace = true}
 log = "0.4"
 sha3 = "0.10"
 

--- a/orchestrator/ethereum_gravity/src/deploy_erc20.rs
+++ b/orchestrator/ethereum_gravity/src/deploy_erc20.rs
@@ -47,8 +47,7 @@ pub async fn deploy_erc20(
         .await?;
 
     if let Some(timeout) = wait_timeout {
-        web3.wait_for_transaction(tx_hash.clone(), timeout, None)
-            .await?;
+        web3.wait_for_transaction(tx_hash, timeout, None).await?;
     }
 
     Ok(tx_hash)

--- a/orchestrator/ethereum_gravity/src/logic_call.rs
+++ b/orchestrator/ethereum_gravity/src/logic_call.rs
@@ -69,7 +69,7 @@ pub async fn send_eth_logic_call(
         .await?;
     info!("Sent batch update with txid {:#066x}", tx);
 
-    web3.wait_for_transaction(tx.clone(), timeout, None).await?;
+    web3.wait_for_transaction(tx, timeout, None).await?;
 
     let last_nonce = get_logic_call_nonce(
         gravity_contract_address,
@@ -108,17 +108,17 @@ pub async fn estimate_logic_call_cost(
 ) -> Result<GasCost, GravityError> {
     let our_balance = web3.eth_get_balance(our_eth_address).await?;
     let our_nonce = web3.eth_get_transaction_count(our_eth_address).await?;
-    let gas_limit = min((u64::MAX - 1).into(), our_balance.clone());
+    let gas_limit = min((u64::MAX - 1).into(), our_balance);
     let gas_price = web3.eth_gas_price().await?;
     // increase the value by 20% without using floating point multiplication
-    let gas_price = gas_price.clone() + (gas_price / 5u8.into());
+    let gas_price = gas_price + (gas_price / 5u8.into());
     let zero: Uint256 = 0u8.into();
     let val = web3
         .eth_estimate_gas(TransactionRequest {
             from: Some(our_eth_address),
             to: gravity_contract_address,
-            nonce: Some(our_nonce.clone().into()),
-            gas_price: Some(gas_price.clone().into()),
+            nonce: Some(our_nonce.into()),
+            gas_price: Some(gas_price.into()),
             gas: Some(gas_limit.into()),
             value: Some(zero.into()),
             data: Some(
@@ -150,11 +150,11 @@ fn encode_logic_call_payload(
     let mut fee_amounts = Vec::new();
     let mut fee_token_contracts = Vec::new();
     for item in call.transfers.iter() {
-        transfer_amounts.push(Token::Uint(item.amount.clone()));
+        transfer_amounts.push(Token::Uint(item.amount));
         transfer_token_contracts.push(item.token_contract_address);
     }
     for item in call.fees.iter() {
-        fee_amounts.push(Token::Uint(item.amount.clone()));
+        fee_amounts.push(Token::Uint(item.amount));
         fee_token_contracts.push(item.token_contract_address);
     }
 

--- a/orchestrator/ethereum_gravity/src/logic_call.rs
+++ b/orchestrator/ethereum_gravity/src/logic_call.rs
@@ -273,13 +273,13 @@ mod tests {
             ethereum_signer,
             eth_signature: Signature {
                 v: 27u8.into(),
-                r: Uint256::from_bytes_be(
+                r: Uint256::from_be_bytes(
                     &hex_str_to_bytes(
                         "0x324da548f6070e8c8d78b205f139138e263d4bad21751e437a7ef31bc53928a8",
                     )
                     .unwrap(),
                 ),
-                s: Uint256::from_bytes_be(
+                s: Uint256::from_be_bytes(
                     &hex_str_to_bytes(
                         "0x03a5f8acc4b6662f839c0f60f5dbfb276957241b7b38feb360d3d7a0b32d63e2",
                     )

--- a/orchestrator/ethereum_gravity/src/message_signatures.rs
+++ b/orchestrator/ethereum_gravity/src/message_signatures.rs
@@ -1,5 +1,5 @@
 use clarity::abi::{encode_tokens, Token};
-use clarity::constants::ZERO_ADDRESS;
+use clarity::constants::zero_address;
 use clarity::utils::get_ethereum_msg_hash;
 use gravity_utils::types::{LogicCall, TransactionBatch, Valset};
 
@@ -13,7 +13,7 @@ pub fn encode_valset_confirm(gravity_id: String, valset: Valset) -> Vec<u8> {
     let reward_token = if let Some(v) = valset.reward_token {
         v
     } else {
-        *ZERO_ADDRESS
+        zero_address()
     };
     encode_tokens(&[
         Token::FixedString(gravity_id),

--- a/orchestrator/ethereum_gravity/src/message_signatures.rs
+++ b/orchestrator/ethereum_gravity/src/message_signatures.rs
@@ -66,11 +66,11 @@ pub fn encode_logic_call_confirm(gravity_id: String, call: LogicCall) -> Vec<u8>
     let mut fee_amounts = Vec::new();
     let mut fee_token_contracts = Vec::new();
     for item in call.transfers.iter() {
-        transfer_amounts.push(Token::Uint(item.amount.clone()));
+        transfer_amounts.push(Token::Uint(item.amount));
         transfer_token_contracts.push(item.token_contract_address);
     }
     for item in call.fees.iter() {
-        fee_amounts.push(Token::Uint(item.amount.clone()));
+        fee_amounts.push(Token::Uint(item.amount));
         fee_token_contracts.push(item.token_contract_address);
     }
 

--- a/orchestrator/ethereum_gravity/src/send_erc721_to_cosmos.rs
+++ b/orchestrator/ethereum_gravity/src/send_erc721_to_cosmos.rs
@@ -36,14 +36,14 @@ pub async fn send_erc721_to_cosmos(
     }
 
     let mut address_approved = web3
-        .check_erc721_approved(erc721, sender_address, token_id.clone())
+        .check_erc721_approved(erc721, sender_address, token_id)
         .await;
     if let Some(w) = wait_timeout {
         let start = Instant::now();
         // keep trying while there's still time
         while address_approved.is_err() && Instant::now() - start < w {
             address_approved = web3
-                .check_erc721_approved(erc721, sender_address, token_id.clone())
+                .check_erc721_approved(erc721, sender_address, token_id)
                 .await;
         }
     }
@@ -55,7 +55,7 @@ pub async fn send_erc721_to_cosmos(
         );
         let mut options = options.clone();
         let nonce = web3.eth_get_transaction_count(sender_address).await?;
-        options.push(SendTxOption::Nonce(nonce.clone()));
+        options.push(SendTxOption::Nonce(nonce));
         approve_nonce = Some(nonce);
 
         let txid = web3
@@ -63,7 +63,7 @@ pub async fn send_erc721_to_cosmos(
                 erc721,
                 sender_secret,
                 gravityerc721_contract,
-                token_id.clone(),
+                token_id,
                 None,
                 options,
             )
@@ -105,11 +105,7 @@ pub async fn send_erc721_to_cosmos(
             gravityerc721_contract,
             encode_call(
                 "sendERC721ToCosmos(address,string,uint256)",
-                &[
-                    erc721.into(),
-                    encoded_destination_address,
-                    token_id.clone().into(),
-                ],
+                &[erc721.into(), encoded_destination_address, token_id.into()],
             )?,
             0u32.into(),
             sender_address,
@@ -119,8 +115,7 @@ pub async fn send_erc721_to_cosmos(
         .await?;
 
     if let Some(timeout) = wait_timeout {
-        web3.wait_for_transaction(tx_hash.clone(), timeout, None)
-            .await?;
+        web3.wait_for_transaction(tx_hash, timeout, None).await?;
     }
 
     Ok(tx_hash)

--- a/orchestrator/ethereum_gravity/src/send_to_cosmos.rs
+++ b/orchestrator/ethereum_gravity/src/send_to_cosmos.rs
@@ -51,7 +51,7 @@ pub async fn send_to_cosmos(
     if !approved {
         let mut options = options.clone();
         let nonce = web3.eth_get_transaction_count(sender_address).await?;
-        options.push(SendTxOption::Nonce(nonce.clone()));
+        options.push(SendTxOption::Nonce(nonce));
         approve_nonce = Some(nonce);
         let txid = web3
             .approve_erc20_transfers(erc20, sender_secret, gravity_contract, None, options)
@@ -92,11 +92,7 @@ pub async fn send_to_cosmos(
             gravity_contract,
             encode_call(
                 "sendToCosmos(address,string,uint256)",
-                &[
-                    erc20.into(),
-                    encoded_destination_address,
-                    amount.clone().into(),
-                ],
+                &[erc20.into(), encoded_destination_address, amount.into()],
             )?,
             0u32.into(),
             sender_address,
@@ -106,8 +102,7 @@ pub async fn send_to_cosmos(
         .await?;
 
     if let Some(timeout) = wait_timeout {
-        web3.wait_for_transaction(tx_hash.clone(), timeout, None)
-            .await?;
+        web3.wait_for_transaction(tx_hash, timeout, None).await?;
     }
 
     Ok(tx_hash)

--- a/orchestrator/ethereum_gravity/src/submit_batch.rs
+++ b/orchestrator/ethereum_gravity/src/submit_batch.rs
@@ -70,7 +70,7 @@ pub async fn send_eth_transaction_batch(
         .await?;
     info!("Sent batch update with txid {:#066x}", tx);
 
-    web3.wait_for_transaction(tx.clone(), timeout, None).await?;
+    web3.wait_for_transaction(tx, timeout, None).await?;
 
     let last_nonce = get_tx_batch_nonce(
         gravity_contract_address,
@@ -106,17 +106,17 @@ pub async fn estimate_tx_batch_cost(
 ) -> Result<GasCost, GravityError> {
     let our_balance = web3.eth_get_balance(our_eth_address).await?;
     let our_nonce = web3.eth_get_transaction_count(our_eth_address).await?;
-    let gas_limit = min((u64::MAX - 1).into(), our_balance.clone());
+    let gas_limit = min((u64::MAX - 1).into(), our_balance);
     let gas_price = web3.eth_gas_price().await?;
     // increase the value by 20% without using floating point multiplication
-    let gas_price = gas_price.clone() + (gas_price / 5u8.into());
+    let gas_price = gas_price + (gas_price / 5u8.into());
     let zero: Uint256 = 0u8.into();
     let val = web3
         .eth_estimate_gas(TransactionRequest {
             from: Some(our_eth_address),
             to: gravity_contract_address,
-            nonce: Some(our_nonce.clone().into()),
-            gas_price: Some(gas_price.clone().into()),
+            nonce: Some(our_nonce.into()),
+            gas_price: Some(gas_price.into()),
             gas: Some(gas_limit.into()),
             value: Some(zero.into()),
             data: Some(encode_batch_payload(current_valset, &batch, confirms, gravity_id)?.into()),

--- a/orchestrator/ethereum_gravity/src/utils.rs
+++ b/orchestrator/ethereum_gravity/src/utils.rs
@@ -1,8 +1,7 @@
 use clarity::abi::encode_call;
 use clarity::Address as EthAddress;
-
 use clarity::Uint256;
-use clarity::{abi::Token, constants::ZERO_ADDRESS};
+use clarity::{abi::Token, constants::zero_address};
 use gravity_utils::num_conversion::downcast_uint256;
 use gravity_utils::types::*;
 use web30::{client::Web3, jsonrpc::error::Web3Error};
@@ -22,7 +21,7 @@ pub async fn get_valset_nonce(
     // submitting millions or tens of millions of dollars
     // worth of transactions. But we properly check and
     // handle that case here.
-    let real_num = Uint256::from_bytes_be(&val);
+    let real_num = Uint256::from_be_bytes(&val);
     Ok(downcast_uint256(real_num).expect("Valset nonce overflow! Bridge Halt!"))
 }
 
@@ -48,7 +47,7 @@ pub async fn get_tx_batch_nonce(
     // submitting millions or tens of millions of dollars
     // worth of transactions. But we properly check and
     // handle that case here.
-    let real_num = Uint256::from_bytes_be(&val);
+    let real_num = Uint256::from_be_bytes(&val);
     Ok(downcast_uint256(real_num).expect("TxBatch nonce overflow! Bridge Halt!"))
 }
 
@@ -78,7 +77,7 @@ pub async fn get_logic_call_nonce(
     // submitting millions or tens of millions of dollars
     // worth of transactions. But we properly check and
     // handle that case here.
-    let real_num = Uint256::from_bytes_be(&val);
+    let real_num = Uint256::from_be_bytes(&val);
     Ok(downcast_uint256(real_num).expect("LogicCall nonce overflow! Bridge Halt!"))
 }
 
@@ -103,7 +102,7 @@ pub async fn get_event_nonce(
     // submitting millions or tens of millions of dollars
     // worth of transactions. But we properly check and
     // handle that case here.
-    let real_num = Uint256::from_bytes_be(&val);
+    let real_num = Uint256::from_be_bytes(&val);
     Ok(downcast_uint256(real_num).expect("EventNonce nonce overflow! Bridge Halt!"))
 }
 
@@ -160,7 +159,7 @@ impl GasCost {
     /// Gets the total cost in Eth (or other EVM chain native token)
     /// of executing the batch
     pub fn get_total(&self) -> Uint256 {
-        self.gas.clone() * self.gas_price.clone()
+        self.gas * self.gas_price
     }
 }
 
@@ -176,12 +175,12 @@ impl GasCost {
 pub fn encode_valset_struct(valset: &Valset) -> Token {
     let (addresses, powers) = valset.to_arrays();
     let nonce = valset.nonce;
-    let reward_amount = valset.reward_amount.clone();
+    let reward_amount = valset.reward_amount;
     // the zero address represents 'no reward' in this case we have replaced it with a 'none'
     // so that it's easy to identify if this validator set has a reward or not. Now that we're
     // going to encode it for the contract call we need return it to the magic value the contract
     // expects.
-    let reward_token = valset.reward_token.unwrap_or(*ZERO_ADDRESS);
+    let reward_token = valset.reward_token.unwrap_or(zero_address());
     let struct_tokens = &[
         addresses.into(),
         powers.into(),

--- a/orchestrator/ethereum_gravity/src/valset_update.rs
+++ b/orchestrator/ethereum_gravity/src/valset_update.rs
@@ -88,17 +88,17 @@ pub async fn estimate_valset_cost(
 ) -> Result<GasCost, GravityError> {
     let our_balance = web3.eth_get_balance(our_eth_address).await?;
     let our_nonce = web3.eth_get_transaction_count(our_eth_address).await?;
-    let gas_limit = min((u64::MAX - 1).into(), our_balance.clone());
+    let gas_limit = min((u64::MAX - 1).into(), our_balance);
     let gas_price = web3.eth_gas_price().await?;
     // increase the value by 20% without using floating point multiplication
-    let gas_price = gas_price.clone() + (gas_price / 5u8.into());
+    let gas_price = gas_price + (gas_price / 5u8.into());
     let zero: Uint256 = 0u8.into();
     let val = web3
         .eth_estimate_gas(TransactionRequest {
             from: Some(our_eth_address),
             to: gravity_contract_address,
-            nonce: Some(our_nonce.clone().into()),
-            gas_price: Some(gas_price.clone().into()),
+            nonce: Some(our_nonce.into()),
+            gas_price: Some(gas_price.into()),
             gas: Some(gas_limit.into()),
             value: Some(zero.into()),
             data: Some(

--- a/orchestrator/gbt/Cargo.toml
+++ b/orchestrator/gbt/Cargo.toml
@@ -20,16 +20,16 @@ relayer = {path = "../relayer/"}
 orchestrator = {path = "../orchestrator/"}
 metrics_exporter = {path = "../metrics_exporter/"}
 
-deep_space = {version="2.15", features=["ethermint"]}
+deep_space = {workspace = true, features=["ethermint"]}
 serde_derive = "1.0"
 serde_json = "1.0"
-clarity = "0.5"
+clarity = {workspace = true}
 clap = {version="3.0.0-rc.7", features=["derive"]}
 serde = "1.0"
 actix-rt = "2.2"
 lazy_static = "1"
 url = "2"
-web30 = "0.22"
+web30 = {workspace = true}
 env_logger = "0.10"
 log = "0.4"
 openssl-probe = "0.1"
@@ -37,6 +37,6 @@ tokio = "1.4"
 rand = "0.8"
 dirs = "4.0"
 toml = "0.5"
-prost = "0.10"
+prost = {workspace = true}
 futures = "0.3"
-tonic = "0.7"
+tonic = {workspace = true}

--- a/orchestrator/gbt/src/client/cosmos_to_eth.rs
+++ b/orchestrator/gbt/src/client/cosmos_to_eth.rs
@@ -88,7 +88,7 @@ pub async fn cosmos_to_eth(
 
     let amount = to_bridge.clone();
     let full_amount = Coin {
-        amount: to_bridge.amount.clone() + chain_fee.amount.clone(),
+        amount: to_bridge.amount + chain_fee.amount,
         denom: to_bridge.denom.clone(),
     };
     check_for_fee(&full_amount, sender_address, contact).await;
@@ -101,7 +101,7 @@ pub async fn cosmos_to_eth(
 
     match balance {
         Some(balance) => {
-            if balance.amount < amount.amount.clone() + bridge_fee.amount.clone() {
+            if balance.amount < amount.amount + bridge_fee.amount {
                 if is_cosmos_originated {
                     error!("Your transfer of {} {} tokens with chain fee {} is greater than your balance of {} tokens. Remember you need some to pay for fees!", print_atom(amount.amount), to_bridge.denom, print_atom(chain_fee.amount), print_atom(balance.amount));
                 } else {

--- a/orchestrator/gbt/src/client/eth_to_cosmos.rs
+++ b/orchestrator/gbt/src/client/eth_to_cosmos.rs
@@ -46,7 +46,7 @@ pub async fn eth_to_cosmos(args: EthToCosmosOpts, prefix: String) {
             erc20_address
         );
         exit(1);
-    } else if amount.clone() > erc20_balance {
+    } else if amount > erc20_balance {
         error!("Insufficient balance {} > {}", amount, erc20_balance);
         exit(1);
     }
@@ -59,7 +59,7 @@ pub async fn eth_to_cosmos(args: EthToCosmosOpts, prefix: String) {
     let res = send_to_cosmos(
         erc20_address,
         gravity_address,
-        amount.clone(),
+        amount,
         cosmos_dest,
         ethereum_key,
         Some(TIMEOUT),

--- a/orchestrator/gbt/src/keys/mod.rs
+++ b/orchestrator/gbt/src/keys/mod.rs
@@ -148,7 +148,7 @@ pub async fn recover_funds(args: RecoverFundsOpts, address_prefix: String) {
             chain_fee
         } else {
             info!("Calculating a reasonable chain fee to pay to Gravity Bridge stakers...");
-            let chain_fee_amount = get_reasonable_send_to_eth_fee(&contact, amount.amount.clone())
+            let chain_fee_amount = get_reasonable_send_to_eth_fee(&contact, amount.amount)
                 .await
                 .map_err(|e| {
                     format!(
@@ -157,7 +157,7 @@ pub async fn recover_funds(args: RecoverFundsOpts, address_prefix: String) {
                     )
                 })
                 .unwrap();
-            amount.amount -= chain_fee_amount.clone();
+            amount.amount -= chain_fee_amount;
             info!("Chain fee calculated ({}), your amount to bridge has been reduced to {} accordingly!", chain_fee_amount, amount.amount);
             Coin {
                 amount: chain_fee_amount,

--- a/orchestrator/gbt/src/orchestrator.rs
+++ b/orchestrator/gbt/src/orchestrator.rs
@@ -2,7 +2,7 @@ use crate::args::OrchestratorOpts;
 use crate::config::config_exists;
 use crate::config::load_keys;
 use crate::utils::print_relaying_explanation;
-use clarity::constants::ZERO_ADDRESS;
+use clarity::constants::zero_address;
 use cosmos_gravity::query::get_gravity_params;
 use deep_space::{CosmosPrivateKey, PrivateKey};
 use gravity_utils::connection_prep::{
@@ -127,7 +127,7 @@ pub async fn orchestrator(
         let c = params.bridge_ethereum_address.parse();
         match c {
             Ok(v) => {
-                if v == *ZERO_ADDRESS {
+                if v == zero_address() {
                     error!("The Gravity address is not yet set as a chain parameter! You must specify --gravity-contract-address");
                     exit(1);
                 }

--- a/orchestrator/gbt/src/relayer.rs
+++ b/orchestrator/gbt/src/relayer.rs
@@ -2,7 +2,7 @@ use crate::args::RelayerOpts;
 use crate::config::config_exists;
 use crate::config::load_keys;
 use crate::utils::print_relaying_explanation;
-use clarity::constants::ZERO_ADDRESS;
+use clarity::constants::zero_address;
 use cosmos_gravity::query::get_gravity_params;
 use deep_space::{CosmosPrivateKey, PrivateKey};
 use gravity_utils::connection_prep::check_for_fee;
@@ -90,7 +90,7 @@ pub async fn relayer(
 
         match c {
             Ok(v) => {
-                if v == *ZERO_ADDRESS {
+                if v == zero_address() {
                     error!("The Gravity address is not yet set as a chain parameter! You must specify --gravity-contract-address");
                     exit(1);
                 }

--- a/orchestrator/gravity_proto/Cargo.toml
+++ b/orchestrator/gravity_proto/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.10"
-prost-types = "0.10"
+prost = {workspace = true}
+prost-types = {workspace = true}
 cosmos-sdk-proto = {package = "cosmos-sdk-proto-althea", version = "0.13", features = ["bech32ibc", "ethermint"]}
-tonic = "0.7"
-deep_space = "2.14"
+tonic = {workspace = true}
+deep_space = {workspace = true}

--- a/orchestrator/gravity_utils/Cargo.toml
+++ b/orchestrator/gravity_utils/Cargo.toml
@@ -9,14 +9,15 @@ edition = "2018"
 [dependencies]
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "2.15"
-web30 = "0.22"
-clarity = "0.5"
-num256 = "0.3"
+deep_space = {workspace = true}
+web30 = {workspace = true}
+clarity = {workspace = true}
+num256 = {workspace = true}
 serde_derive = "1.0"
 serde = "1.0"
 tokio = "1.4"
-tonic = "0.7"
+tonic = {workspace = true}
+num-traits = "0.2"
 num-bigint = "0.4"
 log = "0.4"
 url = "2"

--- a/orchestrator/gravity_utils/src/error.rs
+++ b/orchestrator/gravity_utils/src/error.rs
@@ -4,7 +4,7 @@
 use clarity::Error as ClarityError;
 use deep_space::error::AddressError as CosmosAddressError;
 use deep_space::error::CosmosGrpcError;
-use num_bigint::ParseBigIntError;
+use num256::ParseError;
 use std::fmt::{self, Debug};
 use tokio::time::error::Elapsed;
 use tonic::Status;
@@ -13,7 +13,7 @@ use web30::jsonrpc::error::Web3Error;
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum GravityError {
-    InvalidBigInt(ParseBigIntError),
+    InvalidBigInt(ParseError),
     CosmosGrpcError(CosmosGrpcError),
     CosmosAddressError(CosmosAddressError),
     EthereumRestError(Web3Error),
@@ -26,7 +26,7 @@ pub enum GravityError {
     InvalidEventLogError(String),
     GravityGrpcError(Status),
     InsufficientVotingPowerToPass(String),
-    ParseBigIntError(ParseBigIntError),
+    ParseBigIntError(ParseError),
     ValsetUpToDate,
 }
 
@@ -102,8 +102,8 @@ impl From<CosmosAddressError> for GravityError {
         GravityError::CosmosAddressError(error)
     }
 }
-impl From<ParseBigIntError> for GravityError {
-    fn from(error: ParseBigIntError) -> Self {
+impl From<ParseError> for GravityError {
+    fn from(error: ParseError) -> Self {
         GravityError::InvalidBigInt(error)
     }
 }

--- a/orchestrator/gravity_utils/src/num_conversion.rs
+++ b/orchestrator/gravity_utils/src/num_conversion.rs
@@ -1,6 +1,5 @@
 use clarity::Uint256;
-use std::u128::MAX as U128MAX;
-use std::u64::MAX as U64MAX;
+use num_traits::ToPrimitive;
 
 const ONE_ETH: u128 = 1000000000000000000;
 const ONE_ETH_FLOAT: f64 = ONE_ETH as f64;
@@ -21,35 +20,11 @@ pub fn one_atom() -> Uint256 {
 }
 
 pub fn downcast_uint256(input: Uint256) -> Option<u64> {
-    if input >= U64MAX.into() {
-        None
-    } else {
-        let mut val = input.to_bytes_be();
-        // pad to 8 bytes
-        while val.len() < 8 {
-            val.insert(0, 0);
-        }
-        let mut lower_bytes: [u8; 8] = [0; 8];
-        // get the 'lowest' 8 bytes from a 256 bit integer
-        lower_bytes.copy_from_slice(&val[0..val.len()]);
-        Some(u64::from_be_bytes(lower_bytes))
-    }
+    input.to_u64()
 }
 
 pub fn downcast_to_u128(input: Uint256) -> Option<u128> {
-    if input >= U128MAX.into() {
-        None
-    } else {
-        let mut val = input.to_bytes_be();
-        // pad to 8 bytes
-        while val.len() < 16 {
-            val.insert(0, 0);
-        }
-        let mut lower_bytes: [u8; 16] = [0; 16];
-        // get the 'lowest' 16 bytes from a 256 bit integer
-        lower_bytes.copy_from_slice(&val[0..val.len()]);
-        Some(u128::from_be_bytes(lower_bytes))
-    }
+    input.to_u128()
 }
 
 /// TODO revisit this for higher precision while

--- a/orchestrator/gravity_utils/src/prices.rs
+++ b/orchestrator/gravity_utils/src/prices.rs
@@ -27,7 +27,7 @@ pub async fn get_weth_price_with_retries(
             pubkey,
             token,
             *WETH_CONTRACT_ADDRESS,
-            amount.clone(),
+            amount,
             Some(FIVE_PERCENT),
             None,
         )
@@ -63,7 +63,7 @@ pub async fn get_weth_price(
             token,
             *WETH_CONTRACT_ADDRESS,
             None,
-            amount.clone(),
+            amount,
             Some(slippage_sqrt_price),
             None,
         )
@@ -98,7 +98,7 @@ pub async fn get_dai_price(
             token,
             *DAI_CONTRACT_ADDRESS,
             None,
-            amount.clone(),
+            amount,
             Some(slippage_sqrt_price),
             None,
         )

--- a/orchestrator/gravity_utils/src/types/batches.rs
+++ b/orchestrator/gravity_utils/src/types/batches.rs
@@ -53,8 +53,8 @@ impl TransactionBatch {
         let mut destinations = Vec::new();
         let mut fees = Vec::new();
         for item in self.transactions.iter() {
-            amounts.push(Token::Uint(item.erc20_token.amount.clone()));
-            fees.push(Token::Uint(item.erc20_fee.amount.clone()));
+            amounts.push(Token::Uint(item.erc20_token.amount));
+            fees.push(Token::Uint(item.erc20_fee.amount));
             destinations.push(item.destination)
         }
         assert_eq!(amounts.len(), destinations.len());
@@ -76,15 +76,15 @@ impl TransactionBatch {
         }
 
         let token = self.token_contract;
-        let fee_total = self.total_fee.amount.clone();
+        let fee_total = self.total_fee.amount;
         let mut tx_total: Uint256 = 0u8.into();
         for tx in self.transactions.clone() {
-            tx_total += tx.erc20_token.amount.clone();
+            tx_total += tx.erc20_token.amount;
         }
-        let fee_value_weth = get_weth_price(pubkey, token, fee_total.clone(), web30);
-        let fee_value_dai = get_dai_price(pubkey, token, fee_total.clone(), web30);
-        let tx_value_weth = get_weth_price(pubkey, token, tx_total.clone(), web30);
-        let tx_value_dai = get_dai_price(pubkey, token, tx_total.clone(), web30);
+        let fee_value_weth = get_weth_price(pubkey, token, fee_total, web30);
+        let fee_value_dai = get_dai_price(pubkey, token, fee_total, web30);
+        let tx_value_weth = get_weth_price(pubkey, token, tx_total, web30);
+        let tx_value_dai = get_dai_price(pubkey, token, tx_total, web30);
         let token_symbol = web30.get_erc20_symbol(token, pubkey);
         let current_block = web30.eth_block_number();
         if let (
@@ -166,7 +166,7 @@ impl TryFrom<gravity_proto::gravity::OutgoingTxBatch> for TransactionBatch {
             if let Some(total_fee) = running_total_fee {
                 running_total_fee = Some(Erc20Token {
                     token_contract_address: total_fee.token_contract_address,
-                    amount: total_fee.amount + tx.erc20_fee.amount.clone(),
+                    amount: total_fee.amount + tx.erc20_fee.amount,
                 });
             } else {
                 running_total_fee = Some(tx.erc20_fee.clone())

--- a/orchestrator/gravity_utils/src/types/ethereum_events.rs
+++ b/orchestrator/gravity_utils/src/types/ethereum_events.rs
@@ -10,7 +10,7 @@
 use super::ValsetMember;
 use crate::error::GravityError;
 use crate::num_conversion::downcast_uint256;
-use clarity::constants::ZERO_ADDRESS;
+use clarity::constants::zero_address;
 use clarity::Address as EthAddress;
 use deep_space::utils::bytes_to_hex_str;
 use deep_space::{Address as CosmosAddress, Address, Msg};
@@ -89,7 +89,7 @@ impl ValsetUpdatedEvent {
         let index_start = 0;
         let index_end = index_start + 32;
         let nonce_data = &input[index_start..index_end];
-        let event_nonce = Uint256::from_bytes_be(nonce_data);
+        let event_nonce = Uint256::from_be_bytes(nonce_data);
         if event_nonce > u64::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
                 "Nonce overflow, probably incorrect parsing".to_string(),
@@ -101,7 +101,7 @@ impl ValsetUpdatedEvent {
         let index_start = 32;
         let index_end = index_start + 32;
         let reward_amount_data = &input[index_start..index_end];
-        let reward_amount = Uint256::from_bytes_be(reward_amount_data);
+        let reward_amount = Uint256::from_be_bytes(reward_amount_data);
 
         // reward token
         let index_start = 2 * 32;
@@ -118,7 +118,7 @@ impl ValsetUpdatedEvent {
         let reward_token = reward_token.unwrap();
         // zero address represents no reward, so we replace it here with a none
         // for ease of checking in the future
-        let reward_token = if reward_token == *ZERO_ADDRESS {
+        let reward_token = if reward_token == zero_address() {
             None
         } else {
             Some(reward_token)
@@ -134,7 +134,7 @@ impl ValsetUpdatedEvent {
             ));
         }
 
-        let len_eth_addresses = Uint256::from_bytes_be(&input[index_start..index_end]);
+        let len_eth_addresses = Uint256::from_be_bytes(&input[index_start..index_end]);
         if len_eth_addresses > usize::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
                 "Ethereum array len overflow, probably incorrect parsing".to_string(),
@@ -150,7 +150,7 @@ impl ValsetUpdatedEvent {
             ));
         }
 
-        let len_powers = Uint256::from_bytes_be(&input[index_start..index_end]);
+        let len_powers = Uint256::from_be_bytes(&input[index_start..index_end]);
         if len_powers > usize::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
                 "Powers array len overflow, probably incorrect parsing".to_string(),
@@ -176,7 +176,7 @@ impl ValsetUpdatedEvent {
                 ));
             }
 
-            let power = Uint256::from_bytes_be(&input[power_start..power_end]);
+            let power = Uint256::from_be_bytes(&input[power_start..power_end]);
             // an eth address at 20 bytes is 12 bytes shorter than the Uint256 it's stored in.
             let eth_address = EthAddress::from_slice(&input[address_start + 12..address_end]);
             if eth_address.is_err() {
@@ -233,7 +233,7 @@ impl EthereumEvent for ValsetUpdatedEvent {
             ));
         }
         let valset_nonce_data = &input.topics[1];
-        let valset_nonce = Uint256::from_bytes_be(valset_nonce_data);
+        let valset_nonce = Uint256::from_be_bytes(valset_nonce_data);
         if valset_nonce > u64::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
                 "Nonce overflow, probably incorrect parsing".to_string(),
@@ -303,7 +303,7 @@ impl EthereumEvent for ValsetUpdatedEvent {
             eth_block_height: self.get_block_height(),
             members: self.members.iter().map(|v| v.into()).collect(),
             reward_amount: self.reward_amount.to_string(),
-            reward_token: self.reward_token.unwrap_or(*ZERO_ADDRESS).to_string(),
+            reward_token: self.reward_token.unwrap_or(zero_address()).to_string(),
             orchestrator: orchestrator.to_string(),
         };
         Msg::new(MSG_VALSET_UPDATED_CLAIM_TYPE_URL, claim)
@@ -341,9 +341,9 @@ impl EthereumEvent for TransactionBatchExecutedEvent {
         if let (Some(batch_nonce_data), Some(erc20_data)) =
             (input.topics.get(1), input.topics.get(2))
         {
-            let batch_nonce = Uint256::from_bytes_be(batch_nonce_data);
+            let batch_nonce = Uint256::from_be_bytes(batch_nonce_data);
             let erc20 = EthAddress::from_slice(&erc20_data[12..32])?;
-            let event_nonce = Uint256::from_bytes_be(&input.data);
+            let event_nonce = Uint256::from_be_bytes(&input.data);
             let block_height = if let Some(bn) = input.block_number.clone() {
                 if bn > u64::MAX.into() {
                     return Err(GravityError::InvalidEventLogError(
@@ -467,14 +467,14 @@ impl SendToCosmosEvent {
             ));
         }
 
-        let amount = Uint256::from_bytes_be(&data[32..64]);
-        let event_nonce = Uint256::from_bytes_be(&data[64..96]);
+        let amount = Uint256::from_be_bytes(&data[32..64]);
+        let event_nonce = Uint256::from_be_bytes(&data[64..96]);
 
         // discard words three and four which contain the data type and length
         let destination_str_len_start = 3 * 32;
         let destination_str_len_end = 4 * 32;
         let destination_str_len =
-            Uint256::from_bytes_be(&data[destination_str_len_start..destination_str_len_end]);
+            Uint256::from_be_bytes(&data[destination_str_len_start..destination_str_len_end]);
 
         if destination_str_len > u32::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
@@ -680,7 +680,7 @@ impl Erc20DeployedEvent {
         let index_start = 3 * 32;
         let index_end = index_start + 32;
 
-        let decimals = Uint256::from_bytes_be(&data[index_start..index_end]);
+        let decimals = Uint256::from_be_bytes(&data[index_start..index_end]);
         if decimals > u8::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
                 "Decimals overflow, probably incorrect parsing".to_string(),
@@ -690,7 +690,7 @@ impl Erc20DeployedEvent {
 
         let index_start = 4 * 32;
         let index_end = index_start + 32;
-        let nonce = Uint256::from_bytes_be(&data[index_start..index_end]);
+        let nonce = Uint256::from_be_bytes(&data[index_start..index_end]);
         if nonce > u64::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
                 "Nonce overflow, probably incorrect parsing".to_string(),
@@ -700,7 +700,7 @@ impl Erc20DeployedEvent {
 
         let index_start = 5 * 32;
         let index_end = index_start + 32;
-        let denom_len = Uint256::from_bytes_be(&data[index_start..index_end]);
+        let denom_len = Uint256::from_be_bytes(&data[index_start..index_end]);
         // it's not probable that we have 4+ gigabytes of event data
         if denom_len > u32::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
@@ -753,7 +753,7 @@ impl Erc20DeployedEvent {
             ));
         }
 
-        let erc20_name_len = Uint256::from_bytes_be(&data[index_start..index_end]);
+        let erc20_name_len = Uint256::from_be_bytes(&data[index_start..index_end]);
         // it's not probable that we have 4+ gigabytes of event data
         if erc20_name_len > u32::MAX.into() {
             return Err(GravityError::InvalidEventLogError(
@@ -807,7 +807,7 @@ impl Erc20DeployedEvent {
             ));
         }
 
-        let symbol_len = Uint256::from_bytes_be(&data[index_start..index_end]);
+        let symbol_len = Uint256::from_be_bytes(&data[index_start..index_end]);
         // it's not probable that we have 4+ gigabytes of event data
         if symbol_len > u32::MAX.into() {
             return Err(GravityError::InvalidEventLogError(

--- a/orchestrator/gravity_utils/src/types/ethereum_events.rs
+++ b/orchestrator/gravity_utils/src/types/ethereum_events.rs
@@ -215,7 +215,7 @@ impl ValsetUpdatedEvent {
 
 impl EthereumEvent for ValsetUpdatedEvent {
     fn get_block_height(&self) -> u64 {
-        downcast_uint256(self.block_height.clone()).unwrap()
+        downcast_uint256(self.block_height).unwrap()
     }
 
     fn get_event_nonce(&self) -> u64 {
@@ -241,7 +241,7 @@ impl EthereumEvent for ValsetUpdatedEvent {
         }
         let valset_nonce: u64 = valset_nonce.to_string().parse().unwrap();
 
-        let block_height = if let Some(bn) = input.block_number.clone() {
+        let block_height = if let Some(bn) = input.block_number {
             if bn > u64::MAX.into() {
                 return Err(GravityError::InvalidEventLogError(
                     "Event nonce overflow! probably incorrect parsing".to_string(),
@@ -290,7 +290,7 @@ impl EthereumEvent for ValsetUpdatedEvent {
     fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
         for item in input {
             if item.event_nonce == event_nonce {
-                return Some(item.block_height.clone());
+                return Some(item.block_height);
             }
         }
         None
@@ -330,7 +330,7 @@ pub struct TransactionBatchExecutedEvent {
 
 impl EthereumEvent for TransactionBatchExecutedEvent {
     fn get_block_height(&self) -> u64 {
-        downcast_uint256(self.block_height.clone()).unwrap()
+        downcast_uint256(self.block_height).unwrap()
     }
 
     fn get_event_nonce(&self) -> u64 {
@@ -344,7 +344,7 @@ impl EthereumEvent for TransactionBatchExecutedEvent {
             let batch_nonce = Uint256::from_be_bytes(batch_nonce_data);
             let erc20 = EthAddress::from_slice(&erc20_data[12..32])?;
             let event_nonce = Uint256::from_be_bytes(&input.data);
-            let block_height = if let Some(bn) = input.block_number.clone() {
+            let block_height = if let Some(bn) = input.block_number {
                 if bn > u64::MAX.into() {
                     return Err(GravityError::InvalidEventLogError(
                         "Block height overflow! probably incorrect parsing".to_string(),
@@ -404,7 +404,7 @@ impl EthereumEvent for TransactionBatchExecutedEvent {
     fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
         for item in input {
             if item.event_nonce == event_nonce {
-                return Some(item.block_height.clone());
+                return Some(item.block_height);
             }
         }
         None
@@ -528,7 +528,7 @@ impl SendToCosmosEvent {
 }
 impl EthereumEvent for SendToCosmosEvent {
     fn get_block_height(&self) -> u64 {
-        downcast_uint256(self.block_height.clone()).unwrap()
+        downcast_uint256(self.block_height).unwrap()
     }
 
     fn get_event_nonce(&self) -> u64 {
@@ -540,7 +540,7 @@ impl EthereumEvent for SendToCosmosEvent {
         if let (Some(erc20_data), Some(sender_data)) = topics {
             let erc20 = EthAddress::from_slice(&erc20_data[12..32])?;
             let sender = EthAddress::from_slice(&sender_data[12..32])?;
-            let block_height = if let Some(bn) = input.block_number.clone() {
+            let block_height = if let Some(bn) = input.block_number {
                 if bn > u64::MAX.into() {
                     return Err(GravityError::InvalidEventLogError(
                         "Block height overflow! probably incorrect parsing".to_string(),
@@ -613,7 +613,7 @@ impl EthereumEvent for SendToCosmosEvent {
     fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
         for item in input {
             if item.event_nonce == event_nonce {
-                return Some(item.block_height.clone());
+                return Some(item.block_height);
             }
         }
         None
@@ -864,7 +864,7 @@ impl Erc20DeployedEvent {
 
 impl EthereumEvent for Erc20DeployedEvent {
     fn get_block_height(&self) -> u64 {
-        downcast_uint256(self.block_height.clone()).unwrap()
+        downcast_uint256(self.block_height).unwrap()
     }
 
     fn get_event_nonce(&self) -> u64 {
@@ -876,7 +876,7 @@ impl EthereumEvent for Erc20DeployedEvent {
         if let Some(new_token_contract_data) = token_contract {
             let erc20 = EthAddress::from_slice(&new_token_contract_data[12..32])?;
 
-            let block_height = if let Some(bn) = input.block_number.clone() {
+            let block_height = if let Some(bn) = input.block_number {
                 if bn > u64::MAX.into() {
                     return Err(GravityError::InvalidEventLogError(
                         "Event nonce overflow! probably incorrect parsing".to_string(),
@@ -932,7 +932,7 @@ impl EthereumEvent for Erc20DeployedEvent {
     fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
         for item in input {
             if item.event_nonce == event_nonce {
-                return Some(item.block_height.clone());
+                return Some(item.block_height);
             }
         }
         None
@@ -965,7 +965,7 @@ pub struct LogicCallExecutedEvent {
 
 impl EthereumEvent for LogicCallExecutedEvent {
     fn get_block_height(&self) -> u64 {
-        downcast_uint256(self.block_height.clone()).unwrap()
+        downcast_uint256(self.block_height).unwrap()
     }
 
     fn get_event_nonce(&self) -> u64 {
@@ -998,7 +998,7 @@ impl EthereumEvent for LogicCallExecutedEvent {
     fn get_block_for_nonce(event_nonce: u64, input: &[Self]) -> Option<Uint256> {
         for item in input {
             if item.event_nonce == event_nonce {
-                return Some(item.block_height.clone());
+                return Some(item.block_height);
             }
         }
         None

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -145,9 +145,9 @@ impl Valset {
                     out.push(GravitySignature {
                         power: member.power,
                         eth_address: sig.get_eth_address(),
-                        v: sig.get_signature().v.clone(),
-                        r: sig.get_signature().r.clone(),
-                        s: sig.get_signature().s.clone(),
+                        v: sig.get_signature().v,
+                        r: sig.get_signature().r,
+                        s: sig.get_signature().s,
                     });
                     power_of_good_sigs += member.power;
                 } else {

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::error::GravityError;
-use clarity::constants::ZERO_ADDRESS;
+use clarity::constants::zero_address;
 use clarity::Address as EthAddress;
 use clarity::Signature as EthSignature;
 use deep_space::error::CosmosGrpcError;
@@ -300,7 +300,7 @@ impl From<gravity_proto::gravity::Valset> for Valset {
 impl From<&gravity_proto::gravity::Valset> for Valset {
     fn from(input: &gravity_proto::gravity::Valset) -> Self {
         let parsed_reward_token = input.reward_token.parse().unwrap();
-        let reward_token = if parsed_reward_token == *ZERO_ADDRESS {
+        let reward_token = if parsed_reward_token == zero_address() {
             None
         } else {
             Some(parsed_reward_token)
@@ -427,10 +427,7 @@ impl Into<gravity_proto::gravity::Valset> for &Valset {
             height: 0,
             members: self.members.iter().map(|v| v.into()).collect(),
             reward_amount: self.reward_amount.to_string(),
-            reward_token: self
-                .reward_token
-                .unwrap_or(*clarity::constants::ZERO_ADDRESS)
-                .to_string(),
+            reward_token: self.reward_token.unwrap_or(zero_address()).to_string(),
         }
     }
 }

--- a/orchestrator/orchestrator/Cargo.toml
+++ b/orchestrator/orchestrator/Cargo.toml
@@ -17,21 +17,22 @@ gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 metrics_exporter = {path = "../metrics_exporter/"}
 
-deep_space = "2.15"
+deep_space = {workspace = true}
 serde_derive = "1.0"
-clarity = "0.5"
+clarity = {workspace = true}
 docopt = "1"
 serde = "1.0"
 actix-rt = "2.2"
 lazy_static = "1"
-web30 = "0.22"
-num256 = "0.3"
+web30 = {workspace = true}
+num256 = {workspace = true}
+num-traits = "0.2"
 log = "0.4"
 env_logger = "0.10"
 serde_json = "1.0"
 tokio = "1.4.0"
 rand = "0.8"
-tonic = "0.7"
+tonic = {workspace = true}
 futures = "0.3"
 openssl-probe = "0.1"
 

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -52,17 +52,17 @@ pub async fn check_for_events(
     // if the latest block is more than BLOCKS_TO_SEARCH ahead do not search the full history
     // comparison only to prevent panic on underflow.
     let latest_block = if latest_block > starting_block
-        && latest_block.clone() - starting_block.clone() > BLOCKS_TO_SEARCH.into()
+        && latest_block - starting_block > BLOCKS_TO_SEARCH.into()
     {
-        starting_block.clone() + BLOCKS_TO_SEARCH.into()
+        starting_block + BLOCKS_TO_SEARCH.into()
     } else {
         latest_block
     };
 
     let deposits = web3
         .check_for_events(
-            starting_block.clone(),
-            Some(latest_block.clone()),
+            starting_block,
+            Some(latest_block),
             vec![gravity_contract_address],
             vec![SENT_TO_COSMOS_EVENT_SIG],
         )
@@ -71,8 +71,8 @@ pub async fn check_for_events(
 
     let batches = web3
         .check_for_events(
-            starting_block.clone(),
-            Some(latest_block.clone()),
+            starting_block,
+            Some(latest_block),
             vec![gravity_contract_address],
             vec![TRANSACTION_BATCH_EXECUTED_EVENT_SIG],
         )
@@ -81,8 +81,8 @@ pub async fn check_for_events(
 
     let valsets = web3
         .check_for_events(
-            starting_block.clone(),
-            Some(latest_block.clone()),
+            starting_block,
+            Some(latest_block),
             vec![gravity_contract_address],
             vec![VALSET_UPDATED_EVENT_SIG],
         )
@@ -91,8 +91,8 @@ pub async fn check_for_events(
 
     let erc20_deployed = web3
         .check_for_events(
-            starting_block.clone(),
-            Some(latest_block.clone()),
+            starting_block,
+            Some(latest_block),
             vec![gravity_contract_address],
             vec![ERC20_DEPLOYED_EVENT_SIG],
         )
@@ -101,8 +101,8 @@ pub async fn check_for_events(
 
     let logic_call_executed = web3
         .check_for_events(
-            starting_block.clone(),
-            Some(latest_block.clone()),
+            starting_block,
+            Some(latest_block),
             vec![gravity_contract_address],
             vec![LOGIC_CALL_EVENT_SIG],
         )

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -26,6 +26,7 @@ use gravity_proto::cosmos_sdk_proto::cosmos::base::abci::v1beta1::TxResponse;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
 use gravity_utils::types::GravityBridgeToolsConfig;
 use metrics_exporter::{metrics_errors_counter, metrics_latest, metrics_warnings_counter};
+use num_traits::ToPrimitive;
 use relayer::main_loop::all_relayer_loops;
 use std::cmp::min;
 use std::process::exit;
@@ -181,7 +182,7 @@ pub async fn eth_oracle_main_loop(
 
                 metrics_latest(block_height, "latest_cosmos_block");
                 // Converting into u64
-                metrics_latest(latest_eth_block.to_u64_digits()[0], "latest_eth_block");
+                metrics_latest(latest_eth_block.to_u64().unwrap(), "latest_eth_block");
             }
             (Ok(_latest_eth_block), Ok(ChainStatus::Syncing)) => {
                 warn!("Cosmos node syncing, Eth oracle paused");

--- a/orchestrator/orchestrator/src/main_loop.rs
+++ b/orchestrator/orchestrator/src/main_loop.rs
@@ -117,7 +117,7 @@ pub async fn test_eth_connection(web3: Web3) {
         match (latest_res, finalized_res) {
             (Ok(latest), Ok(finalized)) => {
                 if latest.number < finalized.number
-                    || finalized.number.clone() + 32u8.into() > latest.number
+                    || finalized.number + 32u8.into() > latest.number
                 {
                     panic!(
                         "Ethereum RPC returned an invalid 'finalized' block, expecting at least a 32 block difference but found latest block ({}) and 'finalized' block ({})",
@@ -251,7 +251,7 @@ pub async fn eth_oracle_main_loop(
             gravity_contract_address,
             cosmos_key,
             fee.clone(),
-            last_checked_block.clone(),
+            last_checked_block,
         )
         .await
         {

--- a/orchestrator/orchestrator/src/oracle_resync.rs
+++ b/orchestrator/orchestrator/src/oracle_resync.rs
@@ -43,46 +43,46 @@ pub async fn get_last_checked_block(
         last_event_nonce = 1u8.into();
     }
 
-    let mut current_block: Uint256 = latest_block.clone();
+    let mut current_block: Uint256 = latest_block;
 
-    while current_block.clone() > 0u8.into() {
+    while current_block > 0u8.into() {
         info!(
             "Oracle is resyncing, looking back into the history to find our last event nonce {}, on block {}",
             last_event_nonce, current_block
         );
-        let end_search = if current_block.clone() < BLOCKS_TO_SEARCH.into() {
+        let end_search = if current_block < BLOCKS_TO_SEARCH.into() {
             0u8.into()
         } else {
-            current_block.clone() - BLOCKS_TO_SEARCH.into()
+            current_block - BLOCKS_TO_SEARCH.into()
         };
         let batch_events = web3
             .check_for_events(
-                end_search.clone(),
-                Some(current_block.clone()),
+                end_search,
+                Some(current_block),
                 vec![gravity_contract_address],
                 vec![TRANSACTION_BATCH_EXECUTED_EVENT_SIG],
             )
             .await;
         let send_to_cosmos_events = web3
             .check_for_events(
-                end_search.clone(),
-                Some(current_block.clone()),
+                end_search,
+                Some(current_block),
                 vec![gravity_contract_address],
                 vec![SENT_TO_COSMOS_EVENT_SIG],
             )
             .await;
         let erc20_deployed_events = web3
             .check_for_events(
-                end_search.clone(),
-                Some(current_block.clone()),
+                end_search,
+                Some(current_block),
                 vec![gravity_contract_address],
                 vec![ERC20_DEPLOYED_EVENT_SIG],
             )
             .await;
         let logic_call_executed_events = web3
             .check_for_events(
-                end_search.clone(),
-                Some(current_block.clone()),
+                end_search,
+                Some(current_block),
                 vec![gravity_contract_address],
                 vec![LOGIC_CALL_EVENT_SIG],
             )
@@ -95,8 +95,8 @@ pub async fn get_last_checked_block(
         // history
         let valset_events = web3
             .check_for_events(
-                end_search.clone(),
-                Some(current_block.clone()),
+                end_search,
+                Some(current_block),
                 vec![gravity_contract_address],
                 vec![VALSET_UPDATED_EVENT_SIG],
             )

--- a/orchestrator/proto_build/Cargo.toml
+++ b/orchestrator/proto_build/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 
 [dependencies]
-prost = "0.10"
-tonic = "0.7"
+prost = {workspace = true}
+tonic = {workspace = true}
 prost-build = "0.10"
 walkdir = "2"
 tonic-build = "0.7"

--- a/orchestrator/relayer/Cargo.toml
+++ b/orchestrator/relayer/Cargo.toml
@@ -14,19 +14,19 @@ cosmos_gravity = {path = "../cosmos_gravity"}
 gravity_utils = {path = "../gravity_utils"}
 gravity_proto = {path = "../gravity_proto/"}
 
-deep_space = "2.15"
+deep_space = {workspace = true}
 serde_derive = "1.0"
-clarity = "0.5"
+clarity = {workspace = true}
 docopt = "1"
 serde = "1.0"
 actix-rt = "2"
 lazy_static = "1"
-web30 = "0.22"
-num256 = "0.3"
+web30 = {workspace = true}
+num256 = {workspace = true}
 log = "0.4"
 env_logger = "0.10"
 tokio = "1.4"
-tonic = "0.7"
+tonic = {workspace = true}
 openssl-probe = "0.1"
 futures = "0.3"
 

--- a/orchestrator/relayer/src/altruistic.rs
+++ b/orchestrator/relayer/src/altruistic.rs
@@ -77,10 +77,7 @@ pub async fn gas_tracker_loop(web3: &Web3, relayer_config: RelayerConfig) {
         let loop_start = Instant::now();
 
         let current = update_gas_tracker(web3).await;
-        debug!(
-            "Updated gas price history {:?}",
-            current.clone().map(print_gwei),
-        );
+        debug!("Updated gas price history {:?}", current.map(print_gwei),);
 
         delay_until_next_iteration(loop_start, relayer_config.gas_tracker_loop_speed).await;
     }

--- a/orchestrator/relayer/src/batch_relaying.rs
+++ b/orchestrator/relayer/src/batch_relaying.rs
@@ -131,16 +131,11 @@ async fn should_relay_batch(
         return (true, None);
     }
 
-    let batch_reward_amount = batch.total_fee.amount.clone();
+    let batch_reward_amount = batch.total_fee.amount;
     let batch_reward_token = batch.total_fee.token_contract_address;
     // gets the price of the provided amount of the provided token in weth
-    let price = get_weth_price_with_retries(
-        pubkey,
-        batch_reward_token,
-        batch_reward_amount.clone(),
-        web3,
-    )
-    .await;
+    let price =
+        get_weth_price_with_retries(pubkey, batch_reward_token, batch_reward_amount, web3).await;
 
     match config {
         BatchRelayingMode::EveryBatch | BatchRelayingMode::Altruistic => (true, None),
@@ -195,7 +190,7 @@ async fn should_relay_batch(
 fn get_whitelist_price(erc20: EthAddress, whitelist: &[WhitelistToken]) -> Option<(Uint256, u8)> {
     for i in whitelist {
         if i.token == erc20 {
-            return Some((i.price.clone(), i.decimals));
+            return Some((i.price, i.decimals));
         }
     }
     None
@@ -294,7 +289,7 @@ async fn submit_batches(
                 info!(
                     "We have detected a batch to relay. This batch is estimated to cost {} Gas @ {} gwei / {:.4} ETH to submit",
                     cost.gas.clone(),
-                    print_gwei(cost.gas_price.clone()),
+                    print_gwei(cost.gas_price),
                     print_eth(cost.get_total())
                 );
                 oldest_signed_batch
@@ -316,7 +311,7 @@ async fn submit_batches(
                         oldest_signed_batch.token_contract,
                         oldest_signed_batch.nonce,
                         print_eth(cost.get_total()),
-                        reward_in_weth.clone().map(print_eth),
+                        reward_in_weth.map(print_eth),
                     );
                     let res = send_eth_transaction_batch(
                         current_valset.clone(),
@@ -335,7 +330,7 @@ async fn submit_batches(
                 } else {
                     info!(
                         "Not relaying batch {}/{} due to it not being profitable. Cost: {}, Reward: {:?}",
-                        oldest_signed_batch.token_contract, oldest_signed_batch.nonce, print_eth(cost.get_total()), reward_in_weth.clone().map(print_eth),
+                        oldest_signed_batch.token_contract, oldest_signed_batch.nonce, print_eth(cost.get_total()), reward_in_weth.map(print_eth),
                     );
                 }
             }

--- a/orchestrator/relayer/src/find_latest_valset.rs
+++ b/orchestrator/relayer/src/find_latest_valset.rs
@@ -18,22 +18,22 @@ pub async fn find_latest_valset(
 ) -> Result<Valset, GravityError> {
     const BLOCKS_TO_SEARCH: u128 = 5_000u128;
     let latest_block = web3.eth_block_number().await?;
-    let mut current_block: Uint256 = latest_block.clone();
+    let mut current_block: Uint256 = latest_block;
 
-    while current_block.clone() > 0u8.into() {
+    while current_block > 0u8.into() {
         trace!(
             "About to submit a Valset or Batch looking back into the history to find the last Valset Update, on block {}",
             current_block
         );
-        let end_search = if current_block.clone() < BLOCKS_TO_SEARCH.into() {
+        let end_search = if current_block < BLOCKS_TO_SEARCH.into() {
             0u8.into()
         } else {
-            current_block.clone() - BLOCKS_TO_SEARCH.into()
+            current_block - BLOCKS_TO_SEARCH.into()
         };
         let mut all_valset_events = web3
             .check_for_events(
-                end_search.clone(),
-                Some(current_block.clone()),
+                end_search,
+                Some(current_block),
                 vec![gravity_contract_address],
                 vec![VALSET_UPDATED_EVENT_SIG],
             )

--- a/orchestrator/relayer/src/logic_call_relaying.rs
+++ b/orchestrator/relayer/src/logic_call_relaying.rs
@@ -27,7 +27,7 @@ async fn should_relay_logic_call(
     for fee in &logic_call.fees {
         let zero: Uint256 = 0u8.into();
         let reward_token = fee.token_contract_address;
-        let reward_amount = fee.amount.clone();
+        let reward_amount = fee.amount;
         *rewards.entry(reward_token).or_insert(zero) += reward_amount;
     }
     // Check the values in the map to see if we have enough to relay
@@ -35,11 +35,10 @@ async fn should_relay_logic_call(
     for (token, total) in rewards.iter() {
         if *token == *WETH_CONTRACT_ADDRESS {
             // WETH directly counts as ETH
-            total_weth_reward += (*total).clone();
+            total_weth_reward += *total;
         } else {
             // Get the token's value in ETH as of the current moment
-            let weth_equiv =
-                get_weth_price_with_retries(our_address, *token, (*total).clone(), web3).await;
+            let weth_equiv = get_weth_price_with_retries(our_address, *token, *total, web3).await;
             if weth_equiv.is_err() {
                 // Can't get the price so we ignore it
                 info!(
@@ -153,7 +152,7 @@ pub async fn relay_logic_calls(
                 latest_cosmos_call_nonce,
                 latest_ethereum_call,
                 cost.gas.clone(),
-                print_gwei(cost.gas_price.clone()),
+                print_gwei(cost.gas_price),
                 print_eth(cost.get_total())
             );
 

--- a/orchestrator/relayer/src/main_loop.rs
+++ b/orchestrator/relayer/src/main_loop.rs
@@ -96,16 +96,15 @@ pub async fn relayer_main_loop(
             get_acceptable_gas_price(relayer_config.altruistic_acceptable_gas_price_percentage);
         debug!(
             "current ethereum gas price: {:?}, ideal gas price: {:?}",
-            current_gas_price.clone().map(print_gwei),
-            ideal_gas.clone().map(print_gwei)
+            current_gas_price.map(print_gwei),
+            ideal_gas.map(print_gwei)
         );
-        let should_relay_altruistic = if let (Some(current_price), Some(good_price)) =
-            (current_gas_price.clone(), ideal_gas.clone())
-        {
-            current_price <= good_price
-        } else {
-            false
-        };
+        let should_relay_altruistic =
+            if let (Some(current_price), Some(good_price)) = (current_gas_price, ideal_gas) {
+                current_price <= good_price
+            } else {
+                false
+            };
 
         single_relayer_iteration(
             ethereum_key,

--- a/orchestrator/relayer/src/request_batches.rs
+++ b/orchestrator/relayer/src/request_batches.rs
@@ -76,7 +76,7 @@ pub async fn request_batches(
 
         match config.batch_request_mode {
             BatchRequestMode::ProfitableOnly => {
-                let weth_cost_estimate = eth_gas_price.clone() * BATCH_GAS.into();
+                let weth_cost_estimate = eth_gas_price * BATCH_GAS.into();
                 match get_weth_price_with_retries(eth_address, token, total_fee, web30).await {
                     Ok(price) => {
                         if price > weth_cost_estimate {
@@ -110,7 +110,7 @@ pub async fn request_batches(
             BatchRequestMode::Altruistic => {
                 let ideal_gas =
                     get_acceptable_gas_price(config.altruistic_acceptable_gas_price_percentage);
-                let should_request_altruistic = if let Some(good_price) = ideal_gas.clone() {
+                let should_request_altruistic = if let Some(good_price) = ideal_gas {
                     eth_gas_price <= good_price
                 } else {
                     false

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -124,7 +124,7 @@ async fn relay_valid_valset(
        "We have detected that valset {} is valid to submit. Latest on Ethereum is {} This update is estimated to cost {} Gas @ {} Gwei/ {:.4} ETH to submit",
         valset_to_relay.nonce, current_valset.nonce,
         cost.gas.clone(),
-        print_gwei(cost.gas_price.clone()),
+        print_gwei(cost.gas_price),
         print_eth(cost.get_total())
     );
 
@@ -229,13 +229,9 @@ async fn should_relay_valset(
         // if the user has configured only profitable relaying then it is our only consideration
         ValsetRelayingMode::ProfitableOnly { margin } => match valset.reward_token {
             Some(reward_token) => {
-                let price = get_weth_price_with_retries(
-                    pubkey,
-                    reward_token,
-                    valset.reward_amount.clone(),
-                    web3,
-                )
-                .await;
+                let price =
+                    get_weth_price_with_retries(pubkey, reward_token, valset.reward_amount, web3)
+                        .await;
                 let cost_with_margin = get_cost_with_margin(cost.get_total(), *margin);
                 // we need to see how much WETH we can get for the reward token amount,
                 // and compare that value to the gas cost times the margin

--- a/orchestrator/test_runner/Cargo.toml
+++ b/orchestrator/test_runner/Cargo.toml
@@ -17,25 +17,25 @@ gravity_proto = {path = "../gravity_proto/"}
 orchestrator = {path = "../orchestrator/"}
 
 bytes = "1"
-prost = "0.10"
-prost-types = "0.10"
-deep_space = {version = "2.15", features = ["ethermint"]}
+prost = {workspace = true}
+prost-types = {workspace = true}
+deep_space = {workspace = true, features = ["ethermint"]}
 serde_derive = "1.0"
-clarity = "0.5"
+clarity = {workspace = true}
 docopt = "1"
 serde = "1.0"
 actix = "0.13"
 actix-rt = "2.2"
 lazy_static = "1"
 url = "2"
-web30 = "0.22"
+web30 = {workspace = true}
 num = "0.4.0"
-num256 = "0.3"
+num256 = {workspace = true}
 log = "0.4"
 env_logger = "0.10"
 tokio = "1.4.0"
 rand = "0.8"
-tonic = "0.7"
+tonic = {workspace = true}
 futures = "0.3"
 serde_json = "1.0"
 ibc = "0.19.0"

--- a/orchestrator/test_runner/src/airdrop_proposal.rs
+++ b/orchestrator/test_runner/src/airdrop_proposal.rs
@@ -75,7 +75,7 @@ async fn submit_and_pass_airdrop_proposal(
     let starting_amount_in_pool =
         get_coins(&STAKING_TOKEN, &community_pool_contents_start).unwrap();
     let (recipients, amounts) =
-        generate_valid_accounts_and_amounts(num_recipients, starting_amount_in_pool.amount.clone());
+        generate_valid_accounts_and_amounts(num_recipients, starting_amount_in_pool.amount);
 
     let proposal_content = AirdropProposalJson {
         title: format!("Proposal to perform {} airdrop", denom),
@@ -178,7 +178,7 @@ async fn submit_and_fail_airdrop_proposal(
     let (recipients, amounts) = if make_too_many {
         let res = generate_invalid_accounts_and_amounts(
             NUM_AIRDROP_RECIPIENTS,
-            starting_amount_in_pool.amount.clone(),
+            starting_amount_in_pool.amount,
         );
         match res {
             Some(res) => res,
@@ -189,10 +189,7 @@ async fn submit_and_fail_airdrop_proposal(
             }
         }
     } else {
-        generate_valid_accounts_and_amounts(
-            NUM_AIRDROP_RECIPIENTS,
-            starting_amount_in_pool.amount.clone(),
-        )
+        generate_valid_accounts_and_amounts(NUM_AIRDROP_RECIPIENTS, starting_amount_in_pool.amount)
     };
 
     let mut byte_recipients = Vec::new();

--- a/orchestrator/test_runner/src/batch_timeout.rs
+++ b/orchestrator/test_runner/src/batch_timeout.rs
@@ -127,8 +127,7 @@ pub async fn batch_timeout_test(
 
                 // we sent a random amount below 100 tokens to each user, now we're sending
                 // it all back, so we should only be down 500 and whatever ChainFees we paid
-                let min_expected_balance =
-                    starting_eth.clone() - 500u16.into() - max_nonrefundable_amount.clone();
+                let min_expected_balance = starting_eth - 500u16.into() - max_nonrefundable_amount;
 
                 if bal < min_expected_balance {
                     good = false;

--- a/orchestrator/test_runner/src/deposit_overflow.rs
+++ b/orchestrator/test_runner/src/deposit_overflow.rs
@@ -72,7 +72,7 @@ pub async fn deposit_overflow_test(
 
     // NOTE: the dest user's balance should be 1 * normal_amount of check_module_erc20 token
     let mut expected_cosmos_coins = vec![Coin {
-        amount: normal_amount.clone(),
+        amount: normal_amount,
         denom: check_module_denom.clone(),
     }];
     check_cosmos_balances(contact, dest, &expected_cosmos_coins).await;
@@ -84,7 +84,7 @@ pub async fn deposit_overflow_test(
         &orchestrator_keys,
         initial_nonce + 1,
         initial_block_height + 1,
-        max_amount.clone(),
+        max_amount,
         dest,
         *MINER_ADDRESS,
         overflowing_erc20,
@@ -97,7 +97,7 @@ pub async fn deposit_overflow_test(
     // NOTE: the dest user's balance should be 1 * normal_amount of check_module_erc20 token and
     // Uint256 max of false_claims_erc20 token
     expected_cosmos_coins.push(Coin {
-        amount: max_amount.clone(),
+        amount: max_amount,
         denom: overflowing_denom.clone(),
     });
     check_cosmos_balances(contact, dest, &expected_cosmos_coins).await;
@@ -110,7 +110,7 @@ pub async fn deposit_overflow_test(
         &orchestrator_keys,
         initial_nonce + 2,
         initial_block_height + 2,
-        normal_amount.clone(),
+        normal_amount,
         dest,
         *MINER_ADDRESS,
         check_module_erc20,
@@ -123,7 +123,7 @@ pub async fn deposit_overflow_test(
     // Uint256 max of false_claims_erc20 token
     expected_cosmos_coins = vec![
         Coin {
-            amount: normal_amount.clone() + normal_amount.clone(),
+            amount: normal_amount + normal_amount,
             denom: check_module_denom.clone(),
         },
         Coin {
@@ -138,7 +138,7 @@ pub async fn deposit_overflow_test(
         &orchestrator_keys,
         initial_nonce + 3,
         initial_block_height + 3,
-        normal_amount.clone(),
+        normal_amount,
         dest,
         *MINER_ADDRESS,
         overflowing_erc20,
@@ -156,7 +156,7 @@ pub async fn deposit_overflow_test(
         &orchestrator_keys,
         initial_nonce + 4,
         initial_block_height + 4,
-        normal_amount.clone(),
+        normal_amount,
         dest2,
         *MINER_ADDRESS,
         overflowing_erc20,

--- a/orchestrator/test_runner/src/erc_721_happy_path.rs
+++ b/orchestrator/test_runner/src/erc_721_happy_path.rs
@@ -63,14 +63,14 @@ pub async fn erc721_happy_path_test(
             gravity_address,
             gravity_erc721_address,
             erc721_address,
-            Uint256::from_bytes_be(&i.to_be_bytes()),
+            Uint256::from_be_bytes(&i.to_be_bytes()),
             None,
         )
         .await;
     }
 
     info!("testing ERC721 approval utility");
-    let token_id_for_approval = Uint256::from_bytes_be(&203_i32.to_be_bytes());
+    let token_id_for_approval = Uint256::from_be_bytes(&203_i32.to_be_bytes());
     test_erc721_transfer_utils(
         web30,
         gravity_erc721_address,

--- a/orchestrator/test_runner/src/erc_721_happy_path.rs
+++ b/orchestrator/test_runner/src/erc_721_happy_path.rs
@@ -75,7 +75,7 @@ pub async fn erc721_happy_path_test(
         web30,
         gravity_erc721_address,
         erc721_address,
-        token_id_for_approval.clone(),
+        token_id_for_approval,
     )
     .await;
 }
@@ -99,7 +99,7 @@ pub async fn test_erc721_deposit_panic(
         gravity_address,
         gravity_erc721_address,
         erc721_address,
-        token_id.clone(),
+        token_id,
         timeout,
     )
     .await
@@ -145,7 +145,7 @@ pub async fn test_erc721_deposit_result(
     let tx_id = send_erc721_to_cosmos(
         erc721_address,
         gravityerc721_address,
-        token_id.clone(),
+        token_id,
         dest,
         *MINER_PRIVATE_KEY,
         None,
@@ -168,7 +168,7 @@ pub async fn test_erc721_deposit_result(
     while Instant::now() - start < duration {
         // in this while loop wait for owner to change OR wait for event to fire
         let owner = web30
-            .get_erc721_owner_of(erc721_address, *MINER_ADDRESS, token_id.clone())
+            .get_erc721_owner_of(erc721_address, *MINER_ADDRESS, token_id)
             .await;
 
         if owner.unwrap() == gravityerc721_address {
@@ -197,14 +197,14 @@ pub async fn test_erc721_transfer_utils(
         .eth_get_transaction_count(*MINER_ADDRESS)
         .await
         .expect("Error retrieving nonce from eth");
-    options.push(SendTxOption::Nonce(nonce.clone()));
+    options.push(SendTxOption::Nonce(nonce));
 
     match web30
         .approve_erc721_transfers(
             erc721_address,
             *MINER_PRIVATE_KEY,
             gravity_erc721_address,
-            token_id.clone(),
+            token_id,
             None,
             options,
         )

--- a/orchestrator/test_runner/src/ethereum_keys.rs
+++ b/orchestrator/test_runner/src/ethereum_keys.rs
@@ -78,7 +78,7 @@ pub async fn setup_ethermint_test(
     let output = contact
         .send_coins(
             Coin {
-                amount: send_amount.clone(),
+                amount: send_amount,
                 denom: denom.clone(),
             },
             None,
@@ -112,7 +112,7 @@ pub async fn setup_ethermint_test(
         user_address,
         gravity_address,
         erc20_address,
-        send_amount.clone(),
+        send_amount,
     )
     .await
     .unwrap();
@@ -149,7 +149,7 @@ pub async fn example_ethermint_key_usage(
     let user_send = contact
         .send_coins(
             Coin {
-                amount: send_amount.clone(),
+                amount: send_amount,
                 denom: denom.clone(),
             },
             None,
@@ -163,7 +163,7 @@ pub async fn example_ethermint_key_usage(
         .await;
     debug!("user_send is {:?}", user_send);
 
-    let expected_balance = start_balance.amount.clone() - send_amount.clone();
+    let expected_balance = start_balance.amount - send_amount;
     let balance = contact
         .get_balance(user_cosmos_address, denom.clone())
         .await

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -338,7 +338,7 @@ pub async fn test_erc20_deposit_result(
         dest,
         gravity_address,
         erc20_address,
-        amount.clone(),
+        amount,
     )
     .await?;
 
@@ -358,8 +358,8 @@ pub async fn test_erc20_deposit_result(
             (Some(start_coin), Some(end_coin)) => {
                 // When a bridge governance vote happens, the orchestrator will replay all incomplete
                 // sends to cosmos on the next send to cosmos transaction, so we need to use expected_change
-                if let Some(expected) = expected_change.clone() {
-                    if end_coin.amount.clone() - start_coin.amount.clone() == expected
+                if let Some(expected) = expected_change {
+                    if end_coin.amount - start_coin.amount == expected
                         && start_coin.denom == end_coin.denom
                     {
                         info!(
@@ -376,7 +376,7 @@ pub async fn test_erc20_deposit_result(
                             start_coin.amount,
                             amount.clone()
                         );
-                    } else if start_coin.amount + amount.clone() == end_coin.amount
+                    } else if start_coin.amount + amount == end_coin.amount
                         && start_coin.denom == end_coin.denom
                     {
                         info!(
@@ -390,7 +390,7 @@ pub async fn test_erc20_deposit_result(
             (None, Some(end_coin)) => {
                 // When a bridge governance vote happens, the orchestrator will replay all incomplete
                 // sends to cosmos on the next send to cosmos transaction, so we need to use expected_change
-                if let Some(expected) = expected_change.clone() {
+                if let Some(expected) = expected_change {
                     if end_coin.amount == expected {
                         info!(
                             "Successfully bridged ERC20 {}{} to Cosmos! Balance is now {}{}",
@@ -444,7 +444,7 @@ pub async fn send_erc20_deposit(
     let tx_id = send_to_cosmos(
         erc20_address,
         gravity_address,
-        amount.clone(),
+        amount,
         dest,
         *MINER_PRIVATE_KEY,
         None,
@@ -539,7 +539,7 @@ async fn test_batch(
         dest_eth_address,
         Coin {
             denom: token_name.clone(),
-            amount: amount.clone(),
+            amount,
         },
         bridge_denom_fee.clone(),
         None,
@@ -589,7 +589,7 @@ async fn test_batch(
         send_one_eth(dest_eth_address, web30).await;
     }
 
-    check_erc20_balance(erc20_contract, amount.clone(), dest_eth_address, web30).await;
+    check_erc20_balance(erc20_contract, amount, dest_eth_address, web30).await;
     info!(
         "Successfully updated txbatch nonce to {} and sent {}{} tokens to Ethereum!",
         current_eth_batch_nonce, amount, token_name

--- a/orchestrator/test_runner/src/happy_path_v2.rs
+++ b/orchestrator/test_runner/src/happy_path_v2.rs
@@ -66,11 +66,11 @@ pub async fn happy_path_test_v2(
     let chain_fee: Uint256 = 500u64.into(); // A typical chain fee is 2 basis points, this gives us a bit of wiggle room
     let send_to_user_coin = Coin {
         denom: token_to_send_to_eth.clone(),
-        amount: amount_to_bridge.clone() + chain_fee.clone() + 100u8.into(),
+        amount: amount_to_bridge + chain_fee + 100u8.into(),
     };
     let send_to_eth_coin = Coin {
         denom: token_to_send_to_eth.clone(),
-        amount: amount_to_bridge.clone(),
+        amount: amount_to_bridge,
     };
     let chain_fee_coin = Coin {
         denom: token_to_send_to_eth.clone(),
@@ -180,7 +180,7 @@ pub async fn send_to_eth_and_confirm(
     let starting_balance = get_erc20_balance_safe(erc20_contract, web30, eth_receiver)
         .await
         .unwrap();
-    let amount_to_bridge = send_to_eth_coin.amount.clone();
+    let amount_to_bridge = send_to_eth_coin.amount;
     let res = send_to_eth(
         cosmos_key,
         eth_receiver,
@@ -208,11 +208,11 @@ pub async fn send_to_eth_and_confirm(
             continue;
         }
         let balance = new_balance.unwrap();
-        if balance.clone() - starting_balance.clone() == amount_to_bridge {
+        if balance - starting_balance == amount_to_bridge {
             info!("Successfully bridged {} to Ethereum!", amount_to_bridge);
-            assert!(balance == amount_to_bridge.clone());
+            assert!(balance == amount_to_bridge);
             return true;
-        } else if balance.clone() - starting_balance.clone() != 0u8.into() {
+        } else if balance - starting_balance != 0u8.into() {
             error!("Expected {} but got {} instead", amount_to_bridge, balance);
             return false;
         }

--- a/orchestrator/test_runner/src/ibc_auto_forward.rs
+++ b/orchestrator/test_runner/src/ibc_auto_forward.rs
@@ -10,7 +10,7 @@ use clarity::Address as EthAddress;
 use cosmos_gravity::proposals::UPDATE_HRP_IBC_CHANNEL_PROPOSAL;
 use cosmos_gravity::send::MSG_EXECUTE_IBC_AUTO_FORWARDS_TYPE_URL;
 use deep_space::address::Address as CosmosAddress;
-use deep_space::client::msgs::MSG_TRANSFER_TYPE_URL;
+use deep_space::client::type_urls::MSG_TRANSFER_TYPE_URL;
 use deep_space::error::CosmosGrpcError;
 use deep_space::private_key::{CosmosPrivateKey, PrivateKey};
 use deep_space::utils::decode_any;

--- a/orchestrator/test_runner/src/ibc_auto_forward.rs
+++ b/orchestrator/test_runner/src/ibc_auto_forward.rs
@@ -263,7 +263,7 @@ pub async fn test_ibc_transfer(
             let amount_uint = Uint256::from_str(&coin.amount).unwrap();
             let pre_amt = Uint256::from_str(&pre.amount).unwrap();
             let post_amt = Uint256::from_str(&post.amount).unwrap();
-            if post_amt < pre_amt || post_amt - pre_amt.clone() != amount_uint {
+            if post_amt < pre_amt || post_amt - pre_amt != amount_uint {
                 error!(
                     "Incorrect ibc stake balance for user {}: actual {} != expected {}",
                     receiver,
@@ -492,7 +492,7 @@ pub async fn test_ibc_auto_forward_happy_path(
         dest,
         gravity_address,
         erc20_address,
-        amount.clone(),
+        amount,
     )
     .await?;
 
@@ -563,7 +563,7 @@ pub async fn test_ibc_auto_forward_happy_path(
         (Some(pre), Some(post)) => {
             let pre_amt = Uint256::from_str(&pre.amount).unwrap();
             let post_amt = Uint256::from_str(&post.amount).unwrap();
-            if post_amt < pre_amt || pre_amt.clone() - post_amt != amount.clone() {
+            if post_amt < pre_amt || pre_amt - post_amt != amount {
                 panic!(
                     "Incorrect ibc auto-forward balance for user {}: actual {} != expected {}",
                     dest,
@@ -668,7 +668,7 @@ pub async fn test_ibc_auto_forward_failure<
         input.cosmos_receiver,
         input.gravity_address,
         input.erc20_address,
-        input.amount.clone(),
+        input.amount,
     )
     .await?;
 
@@ -770,7 +770,7 @@ pub async fn test_ibc_auto_forward_native_hijack(
         .cosmos_key
         .to_address(&ADDRESS_PREFIX.clone())
         .unwrap();
-    let amt = amount.clone();
+    let amt = amount;
     let ibc_match = move |pre_balance: Option<Coin>, post_balance: Option<Coin>| {
         match (pre_balance, post_balance) {
             (None, None) => {
@@ -804,7 +804,7 @@ pub async fn test_ibc_auto_forward_native_hijack(
                         "User {}'s IBC balance unchanged after native hijack attemt, still need to check local balance",
                         ibc_dest,
                     )
-                } else if post_amt > pre_amt && post_amt - pre_amt.clone() == amt {
+                } else if post_amt > pre_amt && post_amt - pre_amt == amt {
                     panic!(
                         "Discovered native hijack with ibc user {}: actual {} != expected {}",
                         ibc_dest, post.amount, pre_amt
@@ -828,7 +828,7 @@ pub async fn test_ibc_auto_forward_native_hijack(
         };
     };
 
-    let amt = amount.clone();
+    let amt = amount;
     let gravity_match = move |pre_balance: Option<DSCoin>, post_balance: Option<DSCoin>| {
         match (pre_balance, post_balance) {
             (None, None) => {
@@ -853,13 +853,13 @@ pub async fn test_ibc_auto_forward_native_hijack(
                 }
             }
             (Some(pre), Some(post)) => {
-                match post.amount.cmp(&(pre.amount.clone() + amt.clone())) {
+                match post.amount.cmp(&(pre.amount + amt)) {
                     Ordering::Less => {
                         panic!( // At this point there's no explanation for the lack of funds
                            "Failed SendToCosmos native hijack: Discovered unexpected local balance with user {}: actual {} != expected {}",
                            gravity_prefixed_dest,
                            post.amount,
-                           (pre.amount + amt.clone())
+                           (pre.amount + amt)
                         );
                     }
                     Ordering::Equal => {
@@ -873,7 +873,7 @@ pub async fn test_ibc_auto_forward_native_hijack(
                         warn!( // Somehow the balance is less than we would expect
                             "Discovered unexpected native hijack local balance of amount {} != expected {} with user {}",
                             post.amount,
-                            (pre.amount + amt.clone()).to_string(),
+                            (pre.amount + amt).to_string(),
                             gravity_prefixed_dest
                         );
                     }
@@ -936,7 +936,7 @@ pub async fn test_ibc_auto_forward_unregistered_chain(
         .cosmos_key
         .to_address(&ADDRESS_PREFIX.clone())
         .unwrap();
-    let amt = amount.clone();
+    let amt = amount;
     // Ideally we do not see a balance change here
     let ibc_match = move |pre_balance: Option<Coin>, post_balance: Option<Coin>| {
         match (pre_balance, post_balance) {
@@ -967,7 +967,7 @@ pub async fn test_ibc_auto_forward_unregistered_chain(
                 let pre_amt = Uint256::from_str(&pre.amount).unwrap();
                 let post_amt = Uint256::from_str(&post.amount).unwrap();
 
-                if post_amt >= pre_amt && post_amt - pre_amt.clone() == amt {
+                if post_amt >= pre_amt && post_amt - pre_amt == amt {
                     panic!(
                         "Failed SendToCosmos unregistered chain: user {} actual balance {} != expected {}",
                         ibc_address,
@@ -992,7 +992,7 @@ pub async fn test_ibc_auto_forward_unregistered_chain(
         };
     };
 
-    let amt = amount.clone();
+    let amt = amount;
     // Ideally we see the balance increase by amount tokens
     let gravity_match = move |pre_balance: Option<DSCoin>, post_balance: Option<DSCoin>| {
         match (pre_balance, post_balance) {
@@ -1018,13 +1018,13 @@ pub async fn test_ibc_auto_forward_unregistered_chain(
                 }
             }
             (Some(pre), Some(post)) => {
-                match post.amount.cmp(&(pre.amount.clone() + amt.clone())) {
+                match post.amount.cmp(&(pre.amount + amt)) {
                     Ordering::Less => {
                         panic!( // At this point there's no explanation for the lack of funds
                             "Failed SendToCosmos unregistered chain: Discovered unexpected local balance with user {}: actual {} != expected {}",
                             gravity_prefixed_dest,
                             post.amount,
-                            (pre.amount + amt.clone())
+                            (pre.amount + amt)
                         );
                     }
                     Ordering::Equal => {
@@ -1039,7 +1039,7 @@ pub async fn test_ibc_auto_forward_unregistered_chain(
                             "Failed SendToCosmos unregistered chain: Discovered unexpected local balance with user {}: actual {} != expected {}",
                             gravity_prefixed_dest,
                             post.amount,
-                            (pre.amount + amt.clone())
+                            (pre.amount + amt)
                         );
                     }
                 }

--- a/orchestrator/test_runner/src/invalid_events.rs
+++ b/orchestrator/test_runner/src/invalid_events.rs
@@ -265,7 +265,7 @@ pub async fn send_to_cosmos_invalid(
             .eth_get_transaction_count(*MINER_ADDRESS)
             .await
             .unwrap();
-        let options = vec![SendTxOption::Nonce(nonce.clone())];
+        let options = vec![SendTxOption::Nonce(nonce)];
         approve_nonce = Some(nonce);
         let txid = web3
             .approve_erc20_transfers(erc20, *MINER_PRIVATE_KEY, gravity_contract, None, options)
@@ -295,11 +295,7 @@ pub async fn send_to_cosmos_invalid(
             gravity_contract,
             encode_call(
                 "sendToCosmos(address,string,uint256)",
-                &[
-                    erc20.into(),
-                    encoded_destination_address,
-                    one_eth().clone().into(),
-                ],
+                &[erc20.into(), encoded_destination_address, one_eth().into()],
             )
             .unwrap(),
             0u32.into(),
@@ -310,7 +306,7 @@ pub async fn send_to_cosmos_invalid(
         .await
         .unwrap();
 
-    web3.wait_for_transaction(tx_hash.clone(), TOTAL_TIMEOUT, None)
+    web3.wait_for_transaction(tx_hash, TOTAL_TIMEOUT, None)
         .await
         .unwrap();
 }
@@ -355,7 +351,7 @@ async fn deploy_invalid_erc20(
         .unwrap();
 
     web30
-        .wait_for_transaction(tx_hash.clone(), TOTAL_TIMEOUT, None)
+        .wait_for_transaction(tx_hash, TOTAL_TIMEOUT, None)
         .await
         .unwrap();
 

--- a/orchestrator/test_runner/src/pause_bridge.rs
+++ b/orchestrator/test_runner/src/pause_bridge.rs
@@ -122,11 +122,11 @@ pub async fn pause_bridge_test(
         amount: 1u64.into(),
     };
     let amount = amount - 5u64.into();
-    let chain_fee = get_reasonable_send_to_eth_fee(contact, amount.clone())
+    let chain_fee = get_reasonable_send_to_eth_fee(contact, amount)
         .await
         .expect("Unable to get reasonable SendToEth fee");
     let chain_fee_coin = Coin {
-        amount: chain_fee.clone(),
+        amount: chain_fee,
         denom: token_name.clone(),
     };
     send_to_eth(
@@ -134,7 +134,7 @@ pub async fn pause_bridge_test(
         user_keys.eth_address,
         Coin {
             denom: token_name.clone(),
-            amount: amount.clone(),
+            amount,
         },
         bridge_denom_fee.clone(),
         Some(chain_fee_coin),

--- a/orchestrator/test_runner/src/relay_market.rs
+++ b/orchestrator/test_runner/src/relay_market.rs
@@ -176,7 +176,7 @@ async fn setup_batch_test(
         .unwrap()
         .unwrap();
     let cdai_name = cdai_held.denom.clone();
-    let cdai_amount = cdai_held.amount.clone();
+    let cdai_amount = cdai_held.amount;
     info!(
         "generated address' cosmos balance of {} is {}",
         cdai_name, cdai_amount
@@ -197,7 +197,7 @@ async fn setup_batch_test(
         dest_eth_address,
         Coin {
             denom: cdai_name.clone(),
-            amount: send_amount.clone(),
+            amount: send_amount,
         },
         bridge_denom_fee.clone(),
         None,

--- a/orchestrator/test_runner/src/send_to_eth_fees.rs
+++ b/orchestrator/test_runner/src/send_to_eth_fees.rs
@@ -844,9 +844,8 @@ fn setup_transactions(
     // Convert the minimum fee param to a useable fee for a send of one eth (1 * 10^18)
     let curr_fee_basis_points = Uint256::from(min_fee_basis_points);
     let erc20_bridge_amount: Uint256 = one_eth();
-    let erc20_min_fee =
-        get_min_send_to_eth_fee(erc20_bridge_amount.clone(), curr_fee_basis_points.clone());
-    let erc20_success_fees: Vec<Uint256> = get_success_test_fees(erc20_min_fee.clone());
+    let erc20_min_fee = get_min_send_to_eth_fee(erc20_bridge_amount, curr_fee_basis_points);
+    let erc20_success_fees: Vec<Uint256> = get_success_test_fees(erc20_min_fee);
     let erc20_fail_fees: Vec<Uint256> = get_fail_test_fees(erc20_min_fee);
     info!(
         "setup_transactions: Created erc20 fees: \nSuccess [{:?}]\nFailure[{:?}]",
@@ -855,9 +854,8 @@ fn setup_transactions(
 
     // ... and for a send of one atom (1 * 10^6)
     let cosmos_bridge_amount = one_atom();
-    let cosmos_min_fee =
-        get_min_send_to_eth_fee(cosmos_bridge_amount.clone(), curr_fee_basis_points);
-    let cosmos_success_fees: Vec<Uint256> = get_success_test_fees(cosmos_min_fee.clone());
+    let cosmos_min_fee = get_min_send_to_eth_fee(cosmos_bridge_amount, curr_fee_basis_points);
+    let cosmos_success_fees: Vec<Uint256> = get_success_test_fees(cosmos_min_fee);
     let cosmos_fail_fees: Vec<Uint256> = get_fail_test_fees(cosmos_min_fee);
     info!(
         "setup_transactions: Created footoken fees: \nSuccess [{:?}]\nFailure[{:?}]",
@@ -877,7 +875,7 @@ fn setup_transactions(
     // Create some footoken success test cases from the above generated values
     queue_sends_to_eth(
         tests_per_fee_amount,
-        cosmos_bridge_amount.clone(),
+        cosmos_bridge_amount,
         cosmos_success_fees,
         &mut cosmos_good_amounts,
         &mut cosmos_good_fees,
@@ -893,7 +891,7 @@ fn setup_transactions(
     // Create some erc20 success test cases from the above generated values
     queue_sends_to_eth(
         tests_per_fee_amount,
-        erc20_bridge_amount.clone(),
+        erc20_bridge_amount,
         erc20_good_fees.clone(),
         &mut erc20_good_amounts,
         &mut erc20_good_fees,
@@ -958,8 +956,8 @@ fn queue_sends_to_eth(
 ) {
     for fee in fee_amounts {
         for _ in 0..tests_per_fee_amount {
-            bridge_collection.push(bridge_amount.clone());
-            fee_collection.push(fee.clone());
+            bridge_collection.push(bridge_amount);
+            fee_collection.push(fee);
         }
     }
 }
@@ -967,7 +965,7 @@ pub fn get_success_test_fees(min_fee: Uint256) -> Vec<Uint256> {
     if min_fee == 0u8.into() {
         vec![0u8.into(), 1u8.into()]
     } else {
-        vec![min_fee.clone(), min_fee + 10u8.into()]
+        vec![min_fee, min_fee + 10u8.into()]
     }
 }
 

--- a/orchestrator/test_runner/src/tx_cancel.rs
+++ b/orchestrator/test_runner/src/tx_cancel.rs
@@ -58,7 +58,7 @@ pub async fn send_to_eth_and_cancel(
         user_keys.eth_address,
         Coin {
             denom: token_name.clone(),
-            amount: amount.clone(),
+            amount,
         },
         bridge_denom_fee.clone(),
         None,

--- a/orchestrator/test_runner/src/unhalt_bridge.rs
+++ b/orchestrator/test_runner/src/unhalt_bridge.rs
@@ -137,7 +137,7 @@ pub async fn unhalt_bridge_test(
 
     info!("Checking that bridge is halted!");
 
-    let halted_bridge_amt = Uint256::from_str("100_000_000_000_000_000").unwrap();
+    let halted_bridge_amt = Uint256::from_str("100000000000000000").unwrap();
     // Attempt transaction on halted bridge
     let res = test_erc20_deposit_result(
         web30,
@@ -209,7 +209,7 @@ pub async fn unhalt_bridge_test(
     info!("Observing attestations before bridging asset to cosmos!");
     print_sends_to_cosmos(&grpc_client, true).await;
 
-    let fixed_bridge_amt = Uint256::from_str("50_000_000_000_000_000").unwrap();
+    let fixed_bridge_amt = Uint256::from_str("50000000000000000").unwrap();
     info!("Attempting to resend now that the bridge should be fixed");
     // After the reset, we checked that the deposit submitted during the period when the bridge
     // was halted has been bridged after the chain was unhalted. Increase for the new deposit call

--- a/orchestrator/test_runner/src/unhalt_bridge.rs
+++ b/orchestrator/test_runner/src/unhalt_bridge.rs
@@ -146,7 +146,7 @@ pub async fn unhalt_bridge_test(
         bridge_user.cosmos_address,
         gravity_address,
         erc20_address,
-        halted_bridge_amt.clone(),
+        halted_bridge_amt,
         Some(Duration::from_secs(30)),
         None,
     )
@@ -221,7 +221,7 @@ pub async fn unhalt_bridge_test(
         bridge_user.cosmos_address,
         gravity_address,
         erc20_address,
-        fixed_bridge_amt.clone(),
+        fixed_bridge_amt,
         None,
         None,
     )

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -127,7 +127,7 @@ pub async fn send_erc20_bulk(
     destinations: &[EthAddress],
     web3: &Web3,
 ) {
-    check_erc20_balance(erc20, amount.clone(), *MINER_ADDRESS, web3).await;
+    check_erc20_balance(erc20, amount, *MINER_ADDRESS, web3).await;
     let mut nonce = web3
         .eth_get_transaction_count(*MINER_ADDRESS)
         .await
@@ -135,13 +135,13 @@ pub async fn send_erc20_bulk(
     let mut transactions = Vec::new();
     for address in destinations {
         let send = web3.erc20_send(
-            amount.clone(),
+            amount,
             *address,
             erc20,
             *MINER_PRIVATE_KEY,
             Some(OPERATION_TIMEOUT),
             vec![
-                SendTxOption::Nonce(nonce.clone()),
+                SendTxOption::Nonce(nonce),
                 SendTxOption::GasLimit(100_000u32.into()),
                 SendTxOption::GasPriceMultiplier(5.0),
             ],
@@ -153,7 +153,7 @@ pub async fn send_erc20_bulk(
     wait_for_txids(txids, web3).await;
     let mut balance_checks = Vec::new();
     for address in destinations {
-        let check = check_erc20_balance(erc20, amount.clone(), *address, web3);
+        let check = check_erc20_balance(erc20, amount, *address, web3);
         balance_checks.push(check);
     }
     join_all(balance_checks).await;
@@ -173,10 +173,10 @@ pub async fn send_eth_bulk(amount: Uint256, destinations: &[EthAddress], web3: &
     for address in destinations {
         let t = Transaction {
             to: *address,
-            nonce: nonce.clone(),
+            nonce,
             gas_price: HIGH_GAS_PRICE.into(),
             gas_limit: 24000u64.into(),
-            value: amount.clone(),
+            value: amount,
             data: Vec::new(),
             signature: None,
         };
@@ -212,7 +212,7 @@ pub async fn check_erc20_balance(
 ) {
     let new_balance = get_erc20_balance_safe(erc20, web3, address).await;
     let new_balance = new_balance.unwrap();
-    assert!(new_balance >= amount.clone());
+    assert!(new_balance >= amount);
 }
 
 /// utility function for bulk checking erc20 balances, used to provide
@@ -709,7 +709,7 @@ pub async fn get_validator_to_delegate_to(contact: &Contact) -> (CosmosAddress, 
     let mut lowest = 0u8.into();
     for v in validators {
         let amount: Uint256 = v.tokens.parse().unwrap();
-        total_bonded_stake += amount.clone();
+        total_bonded_stake += amount;
 
         if lowest == 0u8.into() || amount < lowest {
             lowest = amount;

--- a/orchestrator/test_runner/src/vesting.rs
+++ b/orchestrator/test_runner/src/vesting.rs
@@ -70,7 +70,7 @@ pub async fn vesting_test(contact: &Contact, vesting_keys: Vec<CosmosPrivateKey>
     let mut lo_in_progress = zero_stake.clone();
     lo_in_progress.amount = "1".to_string();
     let mut hi_in_progress = zero_stake.clone();
-    hi_in_progress.amount = (expected_amount.clone() - 1u8.into()).to_string();
+    hi_in_progress.amount = (expected_amount - 1u8.into()).to_string();
     let _ = check_vesting_accounts_at_height(
         contact,
         &bank_qc,


### PR DESCRIPTION
Cargo has an amazing feature where dependencies can be declared at the workspace level and inherited by member crates: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

This PR also updates num256/clarity to use the bnum implementation of Uint256