### PR TITLE
Orion without balance checking

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -304,20 +304,20 @@ jobs:
         run: tests/all-up-test.sh ERC721_HAPPY_PATH
         env:
           NO_IMAGE_BUILD: True
-#  upgrade_test:
-#    runs-on: ubuntu-latest
-#    needs: happy-path-geth
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: jpribyl/action-docker-layer-caching@v0.1.1
-#        with:
-#          key: integration-test-cache-{hash}
-#          restore-keys: |
-#            integration-test-cache-
-#      - name: Test Pleiades upgrade
-#        run: tests/run-upgrade-test.sh v1.6.5
-#        env:
-#          NO_IMAGE_BUILD: True
+  upgrade_test:
+    runs-on: ubuntu-latest
+    needs: happy-path-geth
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+        with:
+          key: integration-test-cache-{hash}
+          restore-keys: |
+            integration-test-cache-
+      - name: Test Pleiades upgrade
+        run: tests/run-upgrade-test.sh v1.8.2
+        env:
+          NO_IMAGE_BUILD: True
   ibc_auto_forward_test:
     runs-on: ubuntu-latest
     needs: happy-path-geth

--- a/docs/design/oracle.md
+++ b/docs/design/oracle.md
@@ -4,7 +4,7 @@ As part of operating the Gravity bridge all validators run an `Oracle` this Ethe
 
 This process connects to an Ethereum node to monitor the Ethereum blockchain for new events involving the `Gravity Contract`.
 
-The `Gravity Contract` assigns every event a monotonically increasing `event_nonce` with no gaps. This nonces is the unique coordinating value for the Oracle. Every event has the `event_nonce` attached, this is used to ensure that when a validator submits a claim stating it has seen a specific event happening on Ethereum the ordering is unambiguous.
+The `Gravity Contract` assigns every event a strictly increasing `event_nonce` with no gaps. This nonce is the unique coordinating value for the Oracle. Every event has the `event_nonce` attached, this is used to ensure an unambiguous ordering when when a validator submits a claim stating it has seen a specific event happening on Ethereum.
 
 - An `Oracle` observes an event on the Ethereum chain, it packages this event into a `Claim` and submits this claim to the cosmos chain as an [Oracle message](/docs/design/messages.md##Oracle-messages)
 - Within the Gravity Cosmos module this `Claim` either creates or is added to an existing `Attestation` that matches the details of the `Claim` once more than 66% of the active `Validator` set has made a `Claim` that matches the given `Attestation` the `Attestation` is executed. This may mint tokens, burn tokens, or whatever is appropriate for this particular event.

--- a/module/app/upgrades/orion/README.md
+++ b/module/app/upgrades/orion/README.md
@@ -1,0 +1,8 @@
+# Orion UPGRADE
+The *Orion* upgrade contains the following changes.
+
+## Summary of Changes
+
+* Updating Cosmos SDK version to v0.45.13, which is what the Cosmos Hub is currently running.
+* Fee Collection Correction: Fees collected when sending tokens to Ethereum are being moved later in the transaction processing stage, meaning that the 2 basis point fee will only be collected if your message is successful.
+* Upgrades to GBT dependencies including H2, Openssl, and Clarity which now uses the bnum library for uint256 math

--- a/module/app/upgrades/orion/constants.go
+++ b/module/app/upgrades/orion/constants.go
@@ -1,0 +1,3 @@
+package orion
+
+var PleiadesPart2ToOrionPlanName = "orion"

--- a/module/app/upgrades/orion/handler.go
+++ b/module/app/upgrades/orion/handler.go
@@ -1,0 +1,32 @@
+package orion
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+func GetOrionUpgradeHandler(
+	mm *module.Manager, configurator *module.Configurator, crisisKeeper *crisiskeeper.Keeper,
+) func(
+	ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap,
+) (module.VersionMap, error) {
+	if mm == nil {
+		panic("Nil argument to GetOrionUpgradeHandler")
+	}
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vmap module.VersionMap) (module.VersionMap, error) {
+		ctx.Logger().Info("Orion upgrade: Starting upgrade")
+
+		ctx.Logger().Info("Orion Upgrade: Running any configured module migrations")
+		out, outErr := mm.RunMigrations(ctx, *configurator, vmap)
+		if outErr != nil {
+			return out, outErr
+		}
+		ctx.Logger().Info("Asserting invariants after upgrade")
+		crisisKeeper.AssertInvariants(ctx)
+
+		ctx.Logger().Info("Orion Upgrade Successful")
+		return out, nil
+	}
+}

--- a/module/app/upgrades/register.go
+++ b/module/app/upgrades/register.go
@@ -12,6 +12,7 @@ import (
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v3/modules/apps/transfer/keeper"
 
+	"github.com/Gravity-Bridge/Gravity-Bridge/module/app/upgrades/orion"
 	"github.com/Gravity-Bridge/Gravity-Bridge/module/app/upgrades/pleiades"
 	polaris "github.com/Gravity-Bridge/Gravity-Bridge/module/app/upgrades/polaris"
 	v2 "github.com/Gravity-Bridge/Gravity-Bridge/module/app/upgrades/v2"
@@ -57,5 +58,10 @@ func RegisterUpgradeHandlers(
 	upgradeKeeper.SetUpgradeHandler(
 		pleiades.PleiadesPart1ToPart2PlanName,
 		pleiades.GetPleiades2UpgradeHandler(mm, configurator, crisisKeeper, stakingKeeper),
+	)
+
+	upgradeKeeper.SetUpgradeHandler(
+		orion.PleiadesPart2ToOrionPlanName,
+		orion.GetOrionUpgradeHandler(mm, configurator, crisisKeeper),
 	)
 }

--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -140,7 +140,7 @@ func attestationTally(ctx sdk.Context, k keeper.Keeper) {
 
 // cleanupTimedOutBatches deletes batches that have passed their expiration on Ethereum
 // keep in mind several things when modifying this function
-// A) unlike nonces timeouts are not monotonically increasing, meaning batch 5 can have a later timeout than batch 6
+// A) unlike nonces timeouts are not strictly increasing, meaning batch 5 can have a later timeout than batch 6
 // this means that we MUST only cleanup a single batch at a time
 // B) it is possible for ethereumHeight to be zero if no events have ever occurred, make sure your code accounts for this
 // C) When we compute the timeout we do our best to estimate the Ethereum block height at that very second. But what we work with
@@ -162,7 +162,7 @@ func cleanupTimedOutBatches(ctx sdk.Context, k keeper.Keeper) {
 
 // cleanupTimedOutBatches deletes logic calls that have passed their expiration on Ethereum
 // keep in mind several things when modifying this function
-// A) unlike nonces timeouts are not monotonically increasing, meaning call 5 can have a later timeout than batch 6
+// A) unlike nonces timeouts are not strictly increasing, meaning call 5 can have a later timeout than batch 6
 // this means that we MUST only cleanup a single call at a time
 // B) it is possible for ethereumHeight to be zero if no events have ever occurred, make sure your code accounts for this
 // C) When we compute the timeout we do our best to estimate the Ethereum block height at that very second. But what we work with

--- a/module/x/gravity/types/msgs.go
+++ b/module/x/gravity/types/msgs.go
@@ -300,7 +300,7 @@ func (msg MsgConfirmLogicCall) GetSigners() []sdk.AccAddress {
 // EthereumClaim represents a claim on ethereum state
 type EthereumClaim interface {
 	// All Ethereum claims that we relay from the Gravity contract and into the module
-	// have a nonce that is monotonically increasing and unique, since this nonce is
+	// have a nonce that is strictly increasing and unique, since this nonce is
 	// issued by the Ethereum contract it is immutable and must be agreed on by all validators
 	// any disagreement on what claim goes to what nonce means someone is lying.
 	GetEventNonce() uint64

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "gbt"
-version = "1.8.1"
+version = "1.9.0"
 dependencies = [
  "actix-rt",
  "clap",

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1460,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -6,7 +6,7 @@ default-members = ["gbt"]
 num256 = "0.5"
 clarity = "0.7"
 web30 = "0.23"
-deep_space = "2.17"
+deep_space = ">=2.17.1, <2.18"
 prost = "0.10"
 prost-types = "0.10"
 tonic = "0.7"

--- a/orchestrator/gbt/Cargo.toml
+++ b/orchestrator/gbt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbt"
-version = "1.8.1"
+version = "1.9.0"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/orchestrator/gravity_proto/src/ethereum_claim.rs
+++ b/orchestrator/gravity_proto/src/ethereum_claim.rs
@@ -4,7 +4,7 @@
 /// EthereumClaim represents a claim on ethereum state
 pub trait EthereumClaim {
     /// All Ethereum claims that we relay from the Gravity contract and into the module
-    /// have a nonce that is monotonically increasing and unique, since this nonce is
+    /// have a nonce that is strictly increasing and unique, since this nonce is
     /// issued by the Ethereum contract it is immutable and must be agreed on by all validators
     /// any disagreement on what claim goes to what nonce means someone is lying.
     fn get_event_nonce(&self) -> u64;

--- a/orchestrator/gravity_utils/src/types/valsets.rs
+++ b/orchestrator/gravity_utils/src/types/valsets.rs
@@ -73,7 +73,7 @@ impl Confirm for ValsetConfirmResponse {
 /// a list of validators, powers, and eth addresses at a given block height
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct Valset {
-    /// The monotonically increasing nonce value used to prevent
+    /// The strictly increasing nonce value used to prevent
     /// validator set update replay
     pub nonce: u64,
     /// Members of the validator set, these are the Ethereum keys of

--- a/orchestrator/test_runner/src/upgrade.rs
+++ b/orchestrator/test_runner/src/upgrade.rs
@@ -72,7 +72,7 @@ pub async fn upgrade_part_1(
     )
     .await;
 
-    let upgrade_height = run_upgrade(contact, keys, "pleiades2".to_string(), false).await;
+    let upgrade_height = run_upgrade(contact, keys, "orion".to_string(), false).await;
 
     // Check that the expected attestations exist
     check_attestations(grpc_client.clone(), MINIMUM_ATTESTATIONS).await;

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -4,14 +4,14 @@ set -eux
 # to be run with any PWD
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
-bash all-up-test.sh
+bash all-up-test.sh # Happy path
 export NO_IMAGE_BUILD=1
 bash all-up-test.sh VALIDATOR_OUT
-bash all-up-test.sh BATCH_STRESS
 bash all-up-test.sh VALSET_STRESS
-bash all-up-test.sh VALSET_REWARDS
+bash all-up-test.sh BATCH_STRESS
 bash all-up-test.sh HAPPY_PATH_V2
 bash all-up-test.sh ORCHESTRATOR_KEYS
+bash all-up-test.sh VALSET_REWARDS
 bash all-up-test.sh EVIDENCE
 bash all-up-test.sh TXCANCEL
 bash all-up-test.sh INVALID_EVENTS
@@ -26,6 +26,9 @@ bash all-up-test.sh IBC_METADATA
 bash all-up-test.sh ERC721_HAPPY_PATH
 bash all-up-test.sh IBC_AUTO_FORWARD
 bash all-up-test.sh ETHEREUM_KEYS
+bash all-up-test.sh BATCH_TIMEOUT
+bash all-up-test.sh VESTING
+bash all-up-test.sh SEND_TO_ETH_FEES
 if [ ! -z "$ALCHEMY_ID" ]; then
     bash all-up-test.sh RELAY_MARKET $ALCHEMY_ID
     bash all-up-test.sh ARBITRARY_LOGIC $ALCHEMY_ID


### PR DESCRIPTION
This is an alternate upgrade path for the Orion upgrade in response to last minute issues found with the balance checking logic.

This change does not introduce cross bridge balance checking or any of it's code, the current code will be rebased on top of this branch and another upgrade can be performed with the finished check. This upgrade, if chosen by the validators would only contains the cosmos-sdk update, gbt deps updates, and move tx fee collection for gravity into the message handler. 