### PR TITLE
Fix: erc20 representation deployment

### DIFF
--- a/orchestrator/gbt/src/client/deploy_erc20_representation.rs
+++ b/orchestrator/gbt/src/client/deploy_erc20_representation.rs
@@ -1,12 +1,10 @@
 use crate::{args::DeployErc20RepresentationOpts, utils::TIMEOUT};
-use clarity::{utils::display_uint256_as_address, Address as EthAddress};
+
 use cosmos_gravity::query::get_gravity_params;
 use ethereum_gravity::deploy_erc20::deploy_erc20;
-use gravity_proto::gravity::{
-    MsgErc20DeployedClaim, QueryAttestationsRequest, QueryDenomToErc20Request,
-};
+use gravity_proto::gravity::{QueryAttestationsRequest, QueryDenomToErc20Request};
 use gravity_utils::connection_prep::{check_for_eth, create_rpc_connections};
-use prost::{bytes::BytesMut, Message};
+
 use std::{
     process::exit,
     time::{Duration, Instant},
@@ -70,7 +68,7 @@ pub async fn deploy_erc20_representation(
                 }
             }
             let decimals = decimals.unwrap();
-            let contract_to_be_adopted = deploy_erc20(
+            let _contract_to_be_adopted = deploy_erc20(
                 metadata.base,
                 metadata.name,
                 metadata.symbol,
@@ -83,13 +81,8 @@ pub async fn deploy_erc20_representation(
             )
             .await
             .unwrap();
-            // converts uint256 contract call response into an ETH address
-            let contract_to_be_adopted: EthAddress =
-                display_uint256_as_address(contract_to_be_adopted)
-                    .parse()
-                    .unwrap();
 
-            info!("We have deployed ERC20 contract {}, waiting to see if the Cosmos chain choses to adopt it", contract_to_be_adopted);
+            info!("We have deployed ERC20 contract, waiting to see if the Cosmos chain choses to adopt it");
 
             let start = Instant::now();
             loop {
@@ -128,23 +121,13 @@ pub async fn deploy_erc20_representation(
                                 // the else condition here should never happen as it would mean we have an event with a nil pointer
                                 if let Some(claim) = a.claim {
                                     if claim.type_url.contains("MsgERC20DeployedClaim") {
-                                        // decode any value to get at the actual contents of this claim
-                                        let mut buf = BytesMut::with_capacity(claim.value.len());
-                                        buf.extend_from_slice(&claim.value);
-                                        let claim_contents = MsgErc20DeployedClaim::decode(buf)
-                                            .expect("Failed to decode claim");
-
-                                        let claim_contract: EthAddress =
-                                            claim_contents.token_contract.parse().unwrap();
-                                        if claim_contract == contract_to_be_adopted {
-                                            if a.observed {
-                                                error!("Your ERC20 contract has been rejected by the Gravity Bridge chain, please check the metadata and try again");
-                                                exit(1);
-                                            } else {
-                                                error!("Validators have not finished processing this deployment event after {} seconds", WAIT_TIME);
-                                                error!("At this time your ERC20 contract may or may not have been adopted by the bridge, you will have to confirm either by checking the erc20_to_denom field of a genesis dump or using the denom_to_erc20 query endpoint.");
-                                                exit(1);
-                                            }
+                                        if a.observed {
+                                            error!("Your ERC20 contract has been rejected by the Gravity Bridge chain, please check the metadata and try again");
+                                            exit(1);
+                                        } else {
+                                            error!("Validators have not finished processing this deployment event after {} seconds", WAIT_TIME);
+                                            error!("At this time your ERC20 contract may or may not have been adopted by the bridge, you will have to confirm either by checking the erc20_to_denom field of a genesis dump or using the denom_to_erc20 query endpoint.");
+                                            exit(1);
                                         }
                                     }
                                 }
@@ -174,13 +157,31 @@ pub async fn deploy_erc20_representation(
 mod tests {
     use super::*;
     use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
+    use gravity_proto::gravity::MsgErc20DeployedClaim;
+    use prost::bytes::BytesMut;
+    use prost::Message;
+
+    #[actix_rt::test]
+    #[ignore]
+    async fn get_representations() {
+        let mut grpc = GravityQueryClient::connect("http://gravitychain.io:9090")
+            .await
+            .unwrap();
+        let res = grpc
+            .denom_to_erc20(QueryDenomToErc20Request {
+                denom: "ugraviton".to_string(),
+            })
+            .await
+            .unwrap();
+        println!("{:?}", res);
+    }
 
     // Check that our attestation querying and decoding will work, this is hand test and should probably
     // be turned into a reusable function in gravity_utils
     #[actix_rt::test]
     #[ignore]
     async fn test_endpoints() {
-        let mut grpc = GravityQueryClient::connect("https://gravitychain.io:9090")
+        let mut grpc = GravityQueryClient::connect("http://gravitychain.io:9090")
             .await
             .unwrap();
         let attestations = grpc


### PR DESCRIPTION
This function was making a pretty obvious error just optimistically interpreting the txid of the deployment tx as the contract that would result from the tx being successful. This is a simple fix that removes that check rather than actually developing a method to get the deployed contract.