### PR TITLE
Enable binary protections for 'make install'

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -39,7 +39,7 @@ for platform in ${TARGET_PLATFORMS} ; do
     then
         export GOFLAGS='-buildmode=pie'
         export CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
-        export CGO_LDFLAGS="-Wl,-z,relro,-z,now -fstack-protector"
+        export CGO_LDFLAGS="-Wl,-z,relro,-z,now"
     fi
 
     make clean

--- a/module/Makefile
+++ b/module/Makefile
@@ -8,6 +8,11 @@ DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bu
 BUILDDIR ?= $(CURDIR)/build
 LEDGER_ENABLED ?= true
 
+# enable binary security features
+export GOFLAGS='-buildmode=pie'
+export CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
+export CGO_LDFLAGS="-Wl,-z,relro,-z,now"
+
 build_tags = netgo
 ifeq ($(LEDGER_ENABLED),true)
   ifeq ($(OS),Windows_NT)
@@ -26,6 +31,7 @@ ifeq ($(LEDGER_ENABLED),true)
       ifeq ($(GCC),)
         $(error gcc not installed for ledger support, please install or set LEDGER_ENABLED=false)
       else
+        # security features required when linking to C code
         build_tags += ledger
       endif
     endif
@@ -58,9 +64,6 @@ install: go.sum install-no-verify
 
 # Runs go install without verifying dependencies, used to make testing faster
 install-no-verify:
-		export GOFLAGS='-buildmode=pie'
-		export CGO_CPPFLAGS="-D_FORTIFY_SOURCE=2"
-		export CGO_LDFLAGS="-Wl,-z,relro,-z,now -fstack-protector"
 		go install $(BUILD_FLAGS) ./cmd/gravity
 
 # Verifies the go modules

--- a/tests/build-container.sh
+++ b/tests/build-container.sh
@@ -21,4 +21,4 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
        echo "Setting --platform=linux/amd64 for Mac M1 compatibility"
        PLATFORM_CMD="--platform=linux/amd64"; fi
 fi
-docker build -t gravity-base $PLATFORM_CMD .
+docker build --ulimit nofile=65536:65536 -t gravity-base $PLATFORM_CMD .

--- a/tests/dockerfile/Dockerfile
+++ b/tests/dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:38
 ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 RUN dnf install -y git make gcc gcc-c++ which iproute iputils procps-ng vim-minimal tmux net-tools htop tar jq npm openssl-devel perl rust cargo golang wget


### PR DESCRIPTION
Previously binary protections where only available in the 'make build-reproducible' flow. There was an attempt to enable them for 'make install' but checking of the binaries showed that it was not effective.

This patch ensures that any time a go binary is built binary security functions are enabled.

Here are outputs from checksec for binaries with and without ledger support respectively.

```
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable	FILE
Full RELRO      No canary found   NX enabled    PIE enabled     No RPATH   No RUNPATH   85747 Symbols	  Yes	5		12		/home/justin/go/bin/gravity
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable	FILE
Full RELRO      No canary found   NX enabled    PIE enabled     No RPATH   No RUNPATH   85290 Symbols	  Yes	2		4		/home/justin/go/bin/gravity
```