### PR TITLE
DO NOT MERGE: Temporary fix for upgrade test

### DIFF
--- a/module/app/upgrades/apollo/handler.go
+++ b/module/app/upgrades/apollo/handler.go
@@ -29,6 +29,8 @@ func GetApolloUpgradeHandler(
 
 		ctx.Logger().Info("Setting the auction module Params")
 		auctionParams := auctiontypes.DefaultParams()
+		// TODO: Revert the commit containing this change after upgrade tests pass
+		auctionParams.AuctionLength = 40
 		auctionKeeper.SetParams(ctx, auctionParams)
 
 		ctx.Logger().Info("Creating the initial auction period (with no active auctions)")

--- a/module/x/auction/abci.go
+++ b/module/x/auction/abci.go
@@ -52,7 +52,6 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 			if auction.HighestBid != nil {
 				acc := sdk.MustAccAddressFromBech32(auction.HighestBid.BidderAddress)
 				balances := k.BankKeeper.GetAllBalances(ctx, acc)
-				fmt.Printf("%v balances %v\n", acc.String(), balances)
 				affectedAccs[auction.HighestBid.BidderAddress] = balances
 			}
 			return false // Continue iterating through all auctions

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "gbt"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "actix-rt",
  "clap",

--- a/orchestrator/gbt/Cargo.toml
+++ b/orchestrator/gbt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gbt"
-version = "1.11.0"
+version = "1.11.1"
 authors = ["Justin Kilpatrick <justin@althea.net>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
This PR includes a change to the Apollo upgrade logic which sets the auction module's AuctionLength Param to be 40 blocks instead of the default value. The upgrade test in GitHub CI always fails without this change because the test will time out before the ~7 days of blocks pass.

This PR SHOULD NOT BE MERGED!