### PR TITLE
Reduce get_attestations() limit

### DIFF
--- a/orchestrator/cosmos_gravity/src/query.rs
+++ b/orchestrator/cosmos_gravity/src/query.rs
@@ -255,7 +255,7 @@ pub async fn get_attestations(
 ) -> Result<Vec<Attestation>, GravityError> {
     let request = client
         .get_attestations(QueryAttestationsRequest {
-            limit: limit.unwrap_or(1000u64),
+            limit: limit.unwrap_or(50u64),
             order_by: String::new(),
             claim_type: String::new(),
             nonce: 0,


### PR DESCRIPTION
This patch reduces the limit in the get_attestations function, while this function is only used in tests in the main gravity repo it is used by the gravity info server to determine when transactions are being finalized.

The 1000 attestation limit is too large and runs into response size errors.