### PR TITLE
Fix Go cli back requests for gravity originated tokens

### DIFF
--- a/module/x/gravity/client/cli/tx.go
+++ b/module/x/gravity/client/cli/tx.go
@@ -420,10 +420,15 @@ func CmdRequestBatch() *cobra.Command {
 			}
 			cosmosAddr := cliCtx.GetFromAddress()
 
-			// TODO: better denom searching
+			var denom = ""
+			if strings.HasPrefix(args[0], "0x") {
+				denom = fmt.Sprintf("gravity%s", args[0])
+			} else {
+				denom = args[0]
+			}
 			msg := types.MsgRequestBatch{
 				Sender: cosmosAddr.String(),
-				Denom:  fmt.Sprintf("gravity%s", args[0]),
+				Denom:  denom,
 			}
 			if err := msg.ValidateBasic(); err != nil {
 				return err


### PR DESCRIPTION
The Go cli always prepended 'gravity' to all inputs in order to format a 0x eth token address into a gravity0x voucher address for the caller. This creates issues when trying to request a cosmos originated token starting with ibc/hash.

This patch adds a simple check that will ensure the denom starts with 0x before making any chnages, allowing users to pass in ibc/hash values, or even gravity0x voucher strings as valid inputs.