### PR TITLE
Run CI tests directly in Github actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,492 +11,390 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
-        continue-on-error: true
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
-      - name: Prune cache to keep the size down
-        run: docker builder prune -af && docker system prune -af
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
+          cache-on-failure: true
       - name: Run all up happy-path test
-        run: tests/all-up-test.sh
+        run: tests/all-up-test-ci.sh
   happy-path-hardhat:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run all up happy-path test
-        run: tests/all-up-test.sh
+        run: tests/all-up-test-ci.sh
         env:
           HARDHAT: True
-          NO_IMAGE_BUILD: True
   validator-out:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run all up test with a validator out
-        run: tests/all-up-test.sh VALIDATOR_OUT
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh VALIDATOR_OUT
   valset-stress:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run all up valset stress test
-        run: tests/all-up-test.sh VALSET_STRESS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh VALSET_STRESS
   batch-stress:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run all up batch stress test
-        run: tests/all-up-test.sh BATCH_STRESS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh BATCH_STRESS
   v2-happy-path:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run Happy path v2 test (Cosmos -> Eth)
-        run: tests/all-up-test.sh V2_HAPPY_PATH
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh V2_HAPPY_PATH
   v2-happy-path-native:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run Happy path v2 test with the native token
-        run: tests/all-up-test.sh V2_HAPPY_PATH_NATIVE
-        env:
-          NO_IMAGE_BUILD: True
-#  relay-market:
-#    runs-on: ubuntu-latest
-#    needs: happy-path-geth
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: jpribyl/action-docker-layer-caching@v0.1.1
-#        with:
-#          key: integration-test-cache-{hash}
-#          restore-keys: |
-#            integration-test-cache-
-#      - name: Run all up relay market test
-#        env:
-#          ALCHEMY_ID: ${{ secrets.ALCHEMY_ID }}
-#          NO_IMAGE_BUILD: True
-#        if: ${{ env.ALCHEMY_ID != '' }}
-#        run: tests/all-up-test.sh RELAY_MARKET $ALCHEMY_ID
+        run: tests/all-up-test-ci.sh V2_HAPPY_PATH_NATIVE
+  #  relay-market:
+  #    runs-on: ubuntu-latest
+  #    needs: happy-path-geth
+  #    steps:
+  #      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v5
+  #      - uses: Swatinem/rust-cache@v2
+  #        with:
+  #          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
+  #      - name: Run all up relay market test
+  #        env:
+  #          ALCHEMY_ID: ${{ secrets.ALCHEMY_ID }}
+  #          NO_IMAGE_BUILD: True
+  #        if: ${{ env.ALCHEMY_ID != '' }}
+  #        run: tests/all-up-test-ci.sh RELAY_MARKET $ALCHEMY_ID
   orchestrator-keys:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run orchestrator key setting test
-        run: tests/all-up-test.sh ORCHESTRATOR_KEYS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh ORCHESTRATOR_KEYS
   valset_update_rewards:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run the validator set update rewards test
-        run: tests/all-up-test.sh VALSET_REWARDS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh VALSET_REWARDS
   evidence_based_slashing:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run the evidence based slashing test
-        run: tests/all-up-test.sh EVIDENCE
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh EVIDENCE
   transaction-cancel:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run the transaction cancel test
-        run: tests/all-up-test.sh TXCANCEL
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh TXCANCEL
   invalid-events:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Submit invalid events
-        run: tests/all-up-test.sh INVALID_EVENTS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh INVALID_EVENTS
   unhalt-bridge:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Halt bridge with ETH hardfork and then unhalt the bridge via governance
-        run: tests/all-up-test.sh UNHALT_BRIDGE
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh UNHALT_BRIDGE
   pause-bridge:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Pause and then resume the bridge via governance
-        run: tests/all-up-test.sh PAUSE_BRIDGE
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh PAUSE_BRIDGE
   deposit-overflow:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Submit an overflowing deposit
-        run: tests/all-up-test.sh DEPOSIT_OVERFLOW
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh DEPOSIT_OVERFLOW
   ethereum-blacklist:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Attempt to deposit to a blacklisted address
-        run: tests/all-up-test.sh ETHEREUM_BLACKLIST
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh ETHEREUM_BLACKLIST
   airdrop_proposal:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Execute a governance powered airdrop
-        run: tests/all-up-test.sh AIRDROP_PROPOSAL
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh AIRDROP_PROPOSAL
   signature_slashing:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test slashing for unsubmitted signatures
-        run: tests/all-up-test.sh SIGNATURE_SLASHING
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh SIGNATURE_SLASHING
   slashing_delegation:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test delegation after slashing
-        run: tests/all-up-test.sh SLASHING_DELEGATION
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh SLASHING_DELEGATION
   ibc_metadata:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test setting metadata for IBC tokens
-        run: tests/all-up-test.sh IBC_METADATA
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh IBC_METADATA
   erc721_happy_path:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test ERC721 happy path
-        run: tests/all-up-test.sh ERC721_HAPPY_PATH
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh ERC721_HAPPY_PATH
   upgrade_test:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test Apollo upgrade
         run: tests/run-upgrade-test.sh v1.10.1
-        env:
-          NO_IMAGE_BUILD: True
   ibc_auto_forward_test:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test Eth->Gravity IBC Auto-Forwarding
-        run: tests/all-up-test.sh IBC_AUTO_FORWARD
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh IBC_AUTO_FORWARD
   ethereum_keys:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test Ethereum Keys signing support between deep_space and Gravity Bridge Chain
-        run: tests/all-up-test.sh ETHEREUM_KEYS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh ETHEREUM_KEYS
   batch_timeout:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test extremely agressive batch timeout scenarios
-        run: tests/all-up-test.sh BATCH_TIMEOUT
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh BATCH_TIMEOUT
   vesting:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test simple vesting account behavior
-        run: tests/all-up-test.sh VESTING
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh VESTING
   send_to_eth_fees:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test Prop 86 Cosmos->Eth fees
-        run: tests/all-up-test.sh SEND_TO_ETH_FEES
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh SEND_TO_ETH_FEES
   ica_host_happy_path:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test the Interchain Accounts Host module functionality with Gravity
-        run: tests/all-up-test.sh ICA_HOST_HAPPY_PATH
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh ICA_HOST_HAPPY_PATH
   inflation-knockdown:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test adjusting inflation parameters via governance
-        run: tests/all-up-test.sh INFLATION_KNOCKDOWN
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh INFLATION_KNOCKDOWN
   eip-712:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test EIP-712 signature verification
-        run: tests/all-up-test.sh EIP712
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh EIP712
   auction-static:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test the auction module with static bids
-        run: tests/all-up-test.sh AUCTION_STATIC
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh AUCTION_STATIC
   auction-random:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test the auction module with random bids
-        run: tests/all-up-test.sh AUCTION_RANDOM
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh AUCTION_RANDOM
   auction-invalid-params:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test auction module params validation
-        run: tests/all-up-test.sh AUCTION_INVALID_PARAMS
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh AUCTION_INVALID_PARAMS
   auction-disable:
     runs-on: ubuntu-latest
     needs: happy-path-geth
     steps:
       - uses: actions/checkout@v2
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+      - uses: actions/setup-go@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          key: integration-test-cache-{hash}
-          restore-keys: |
-            integration-test-cache-
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Test auction module params validation
-        run: tests/all-up-test.sh AUCTION_DISABLE
-        env:
-          NO_IMAGE_BUILD: True
+        run: tests/all-up-test-ci.sh AUCTION_DISABLE

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: orchestrator/
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Build Orchestrator
         run: cd orchestrator && cargo check --all --verbose
   test:
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: orchestrator/
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run Orchestrator tests
         run: cd orchestrator && cargo test --all --release --verbose
   rustfmt:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: orchestrator/
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Check for Clippy lints
         run: rustup component add clippy && cd orchestrator && cargo clippy --all --all-targets --all-features -- -D warnings
   audit:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: orchestrator/
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Run Cargo Audit
         run: cargo install cargo-audit && cd orchestrator && cargo audit
   acl:
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: orchestrator/
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Install bubblewrap
         run: sudo apt-get update ; sudo apt-get install bubblewrap -y
       - name: Run Cargo ACL
@@ -75,6 +75,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: Swatinem/rust-cache@v2
         with:
-          working-directory: orchestrator/
+          workspaces: /home/runner/work/Gravity-Bridge/Gravity-Bridge/orchestrator/
       - name: Cross compile tests
         run: cargo install cross && cd orchestrator && cross test --all --exclude proto_build --release --target aarch64-unknown-linux-gnu

--- a/orchestrator/Cargo.lock
+++ b/orchestrator/Cargo.lock
@@ -4141,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -4162,9 +4162,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -46,6 +46,7 @@ use lazy_static::lazy_static;
 use orch_keys::orch_keys;
 use orch_only::orch_only_test;
 use relay_market::relay_market_test;
+use std::process::exit;
 use std::{env, time::Duration};
 use tokio::time::sleep;
 use transaction_stress_test::transaction_stress_test;
@@ -235,7 +236,7 @@ pub async fn main() {
     if should_deploy_contracts() {
         info!("test-runner in contract deploying mode, deploying contracts, then exiting");
         deploy_contracts(&gravity_contact).await;
-        return;
+        exit(0);
     }
 
     let contracts = parse_contract_addresses();

--- a/tests/all-up-test-ci.sh
+++ b/tests/all-up-test-ci.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# This script is used in Github actions CI to prep and run a testnet environment
+TEST_TYPE=$2
+set -eux
+NODES=4
+FILE_PATH="/home/runner/work/Gravity-Bridge/Gravity-Bridge/"
+
+sudo apt-get update
+sudo apt-get install -y git make gcc g++ iproute2 iputils-ping procps vim tmux net-tools htop tar jq npm libssl-dev perl rustc cargo wget
+
+# only required for deployment script
+npm install -g ts-node && npm install -g typescript
+mkdir geth
+pushd geth/
+wget https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.10-bb74230f.tar.gz
+tar -xvf *
+sudo mv **/geth /usr/bin/geth
+popd
+
+# Download the althea gaia fork as a IBC test chain
+sudo wget https://github.com/althea-net/ibc-test-chain/releases/download/v9.1.2/gaiad-v9.1.2-linux-amd64 -O /usr/bin/gaiad
+
+# Setup Hermes for IBC connections between chains
+pushd /tmp/
+wget https://github.com/informalsystems/ibc-rs/releases/download/v1.7.0/hermes-v1.7.0-x86_64-unknown-linux-gnu.tar.gz
+tar -xvf hermes-v1.7.0-x86_64-unknown-linux-gnu.tar.gz
+sudo mv hermes /usr/bin/
+popd
+
+# make log dirs
+sudo mkdir /ibc-relayer-logs
+sudo touch /ibc-relayer-logs/hermes-logs
+sudo touch /ibc-relayer-logs/channel-creation
+
+pushd module/
+GOPROXY=https://proxy.golang.org make
+make install
+sudo cp ~/go/bin/gravity /usr/bin/gravity
+popd
+pushd solidity/
+HUSKY_SKIP_INSTALL=1 npm install
+npm run typechain
+ls -lah
+ls -lah artifacts/
+ls -lah artifacts/contracts/
+pwd
+popd
+
+sudo bash tests/container-scripts/setup-validators.sh $NODES
+sudo bash tests/container-scripts/setup-ibc-validators.sh $NODES
+sudo bash tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE
+
+# deploy the ethereum contracts
+pushd orchestrator/test_runner
+DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner
+popd
+
+echo "Running ibc relayer in the background, directing output to /ibc-relayer-logs"
+
+bash tests/container-scripts/integration-tests.sh $NODES $TEST_TYPE

--- a/tests/container-scripts/all-up-test-internal.sh
+++ b/tests/container-scripts/all-up-test-internal.sh
@@ -7,7 +7,7 @@ set -eux
 
 bash /gravity/tests/container-scripts/setup-validators.sh $NODES
 bash /gravity/tests/container-scripts/setup-ibc-validators.sh $NODES
-bash /gravity/tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE $ALCHEMY_ID &
+bash /gravity/tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE "/gravity/" $ALCHEMY_ID &
 
 # deploy the ethereum contracts
 pushd /gravity/orchestrator/test_runner

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -3,17 +3,30 @@ NODES=$1
 TEST_TYPE=$2
 set -eu
 
-FILE=/contracts
+FILE=/tmp/contracts
 if test -f "$FILE"; then
 echo "Contracts already deployed, running tests"
 else 
 echo "Testnet is not started yet, please wait before running tests"
-exit 0
+exit 1
 fi 
 
 set +e
 killall -9 test-runner
 set -e
 
-pushd /gravity/orchestrator/test_runner
+GITHUB_ACTIONS_PATH="/home/runner/work/Gravity-Bridge/Gravity-Bridge/"
+DOCKER_PATH="/gravity/"
+
+if [[ -d "$GITHUB_ACTIONS_PATH" ]]; then
+    FOLDER_PATH="$GITHUB_ACTIONS_PATH"
+elif [[ -d "$DOCKER_PATH" ]]; then
+    FOLDER_PATH="$DOCKER_PATH"
+else
+    echo "Error: Neither $GITHUB_ACTIONS_PATH nor $DOCKER_PATH exists."
+    exit 1
+fi
+
+
+pushd $FOLDER_PATH/orchestrator/test_runner
 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner

--- a/tests/container-scripts/run-eth.sh
+++ b/tests/container-scripts/run-eth.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 # Starts the Ethereum testnet chain in the background
 
+GITHUB_ACTIONS_PATH="/home/runner/work/Gravity-Bridge/Gravity-Bridge/"
+DOCKER_PATH="/gravity/"
+
+if [[ -d "$GITHUB_ACTIONS_PATH" ]]; then
+    FOLDER_PATH="$GITHUB_ACTIONS_PATH"
+elif [[ -d "$DOCKER_PATH" ]]; then
+    FOLDER_PATH="$DOCKER_PATH"
+else
+    echo "Error: Neither $GITHUB_ACTIONS_PATH nor $DOCKER_PATH exists."
+    exit 1
+fi
+
 # init the genesis block
 geth --identity "GravityTestnet" \
 --nodiscover \
---networkid 15 init /gravity/tests/assets/ETHGenesis.json
+--networkid 15 init $FOLDER_PATH/tests/assets/ETHGenesis.json
 
 # etherbase is where rewards get sent
 # private key for this address is 0xb1bab011e03a9862664706fc3bbaa1b16651528e5f0e7fbfcbfdd8be302a13e7

--- a/tests/container-scripts/run-testnet.sh
+++ b/tests/container-scripts/run-testnet.sh
@@ -8,6 +8,18 @@ set +u
 TEST_TYPE=$2
 ALCHEMY_ID=$3
 
+GITHUB_ACTIONS_PATH="/home/runner/work/Gravity-Bridge/Gravity-Bridge/"
+DOCKER_PATH="/gravity/"
+
+if [[ -d "$GITHUB_ACTIONS_PATH" ]]; then
+    FOLDER_PATH="$GITHUB_ACTIONS_PATH"
+elif [[ -d "$DOCKER_PATH" ]]; then
+    FOLDER_PATH="$DOCKER_PATH"
+else
+    echo "Error: Neither $GITHUB_ACTIONS_PATH nor $DOCKER_PATH exists."
+    exit 1
+fi
+
 if [[ ! -z ${OLD_BINARY_LOCATION} ]]; then
     BIN=$OLD_BINARY_LOCATION
 fi
@@ -91,17 +103,17 @@ set +u
 # may be different. These two tests have different fork block heights they rely on
 if [[ $TEST_TYPE == *"ARBITRARY_LOGIC"* ]] && [[ ! -z ${ALCHEMY_ID} ]]; then
     export ALCHEMY_ID=$ALCHEMY_ID
-    pushd /gravity/solidity
+    pushd $FOLDER_PATH/solidity
     npm run solidity_test_fork &
     popd
 elif [[ $TEST_TYPE == *"RELAY_MARKET"* ]] && [[ ! -z ${ALCHEMY_ID} ]]; then
     export ALCHEMY_ID=$ALCHEMY_ID
-    pushd /gravity/solidity
+    pushd $FOLDER_PATH/solidity
     npm run evm_fork &
     popd
 # This starts a hardhat test environment with no pre-seeded state, faster to run, not accurate
 elif [[ ! -z "$HARDHAT" ]]; then
-    pushd /gravity/solidity
+    pushd $FOLDER_PATH/solidity
     npm run evm &
     popd
 # This starts the Geth backed testnet with no pre-seeded in state.
@@ -112,7 +124,7 @@ elif [[ ! -z "$HARDHAT" ]]; then
 # hardhat doesn't work for some tests that depend on transactions waiting for blocks, so Geth is the default
 else
     if [[ -z "$(ps -e | grep geth)" ]]; then # Only run-eth if it's not running, which it would be with upgrade tests
-      bash /gravity/tests/container-scripts/run-eth.sh &
+      bash $FOLDER_PATH/tests/container-scripts/run-eth.sh &
     fi
 fi
 sleep 10


### PR DESCRIPTION
This commit modifies the CI test environment to run directly in github actions rather than running inside a container like it would in the local test flow.

This makes it much eaiser to cache build artifacts and resolves issues with github actions no longer allowing enough cache space to make the docker layer cache strategy useful.