### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/module/x/auction/keeper/abci_test.go
+++ b/module/x/auction/keeper/abci_test.go
@@ -66,7 +66,7 @@ func (suite *KeeperTestSuite) TestEndBlockerAuction() {
 	Bid(suite, TestAccounts[1], 2000, 999999, 0, true) // Bid 2000 on first
 	Bid(suite, TestAccounts[0], 1500, 10, 0, false)    // Insufficient fee, insufficient amount
 	Bid(suite, TestAccounts[0], 1500, 3500, 0, false)  // Outbid the initial bid but not the current highest
-	Bid(suite, TestAccounts[0], 2500, 5500, 0, true)   // Outbid the the current highest
+	Bid(suite, TestAccounts[0], 2500, 5500, 0, true)   // Outbid the current highest
 	AdvanceBlock(&ctx, auctionKeeper)
 	Bid(suite, TestAccounts[0], 2300, 9999000, 0, false)  // Rebid but for too low
 	Bid(suite, TestAccounts[0], 2500, 70000700, 0, false) // Rebid but at current highest

--- a/module/x/gravity/spec/05_end_block.md
+++ b/module/x/gravity/spec/05_end_block.md
@@ -43,8 +43,8 @@ Cleanup loops through batches and logic calls in order to clean up the timed out
 
 ### Batches
 
-When a batch of transactions are created they have a specified height of the opposing chain for when the batch becomes invalid. When this happens we must remove them from the store. At the end of every block, we loop through the store of logic calls checking the the timeout heights.
+When a batch of transactions are created they have a specified height of the opposing chain for when the batch becomes invalid. When this happens we must remove them from the store. At the end of every block, we loop through the store of logic calls checking the timeout heights.
 
 ### Logic Calls
 
-When a logic call is created it consists of a timeout height. This height is used to know when the logic call becomes invalid. At the end of every block, we loop through the store of logic calls checking the the timeout heights.
+When a logic call is created it consists of a timeout height. This height is used to know when the logic call becomes invalid. At the end of every block, we loop through the store of logic calls checking the timeout heights.


### PR DESCRIPTION
 remove redundant word in comment