### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/module/x/gravity/keeper/keeper_valset_test.go
+++ b/module/x/gravity/keeper/keeper_valset_test.go
@@ -1,17 +1,17 @@
 package keeper
 
 import (
+	"bytes"
 	"fmt"
+	"slices"
+	"sort"
 	"testing"
 
-	"bytes"
 	_ "github.com/Gravity-Bridge/Gravity-Bridge/module/config"
 	"github.com/Gravity-Bridge/Gravity-Bridge/module/x/gravity/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
-	"sort"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 const (

--- a/module/x/gravity/types/msgs_test.go
+++ b/module/x/gravity/types/msgs_test.go
@@ -3,13 +3,13 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"slices"
 	"testing"
 
 	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func TestValidateMsgSetOrchestratorAddress(t *testing.T) {


### PR DESCRIPTION
Since Go 1.21, the functions in x/exp used here can already be replaced by functions from the standard library.

And also execute goimports.
